### PR TITLE
Expand test coverage: registry, Launcher, and documented OS contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ pnpm-debug.log*
 test-results/
 playwright-report/
 playwright/.cache/
+
+# vitest coverage report
+coverage/

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -44,6 +44,22 @@ async function dismissBootSplash(page: Page) {
   await splash.waitFor({ state: 'hidden', timeout: 10_000 });
 }
 
+async function bootDesktop(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await dismissBootSplash(page);
+  await expect(page.locator('#ct-desktop')).toBeVisible({ timeout: 15_000 });
+}
+
+async function openApp(page: Page, appName: string) {
+  await page.locator('button[aria-label="Open launcher"]').click();
+  const launcher = page.locator('[role="dialog"][aria-label="App launcher"]');
+  await expect(launcher).toBeVisible();
+  await page.locator('input[aria-label="Search apps"]').fill(appName);
+  await page.keyboard.press('Enter');
+  await expect(launcher).toBeHidden();
+  await expect(page.locator(`section[aria-label="${appName} window"]`)).toBeVisible();
+}
+
 // Block external font CDN — otherwise page.goto and page.screenshot hang on
 // `document.fonts.ready`. Fulfill (vs abort) keeps the console clean.
 test.beforeEach(async ({ page }) => {
@@ -97,6 +113,89 @@ test.describe('desktop golden path', () => {
       realErrors,
       `Unexpected console output:\n${realErrors.map((m) => `  [${m.type}] ${m.text}`).join('\n')}`
     ).toEqual([]);
+  });
+});
+
+test.describe('desktop interactions', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('⌘W closes the focused window', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'Projects');
+    const win = page.locator('section[aria-label="Projects window"]');
+    await expect(win).toBeVisible();
+
+    // Focus is set on the window's <section> by Window.tsx when opened; ⌘W is global.
+    await page.keyboard.press('Meta+W');
+    await expect(win).toHaveCount(0);
+  });
+
+  test('Minimize hides the window; clicking the taskbar pill restores it', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'Projects');
+    const win = page.locator('section[aria-label="Projects window"]');
+    await expect(win).toBeVisible();
+
+    await page.locator('button[aria-label="Minimize Projects"]').click();
+    // Window.tsx returns null when minimized, so the <section> is unmounted.
+    await expect(win).toHaveCount(0);
+
+    // Taskbar pill for Projects is now in "min" state; clicking restores it.
+    const pill = page.locator('[role="tab"]', { hasText: 'Projects' });
+    await expect(pill).toBeVisible();
+    await pill.click();
+    await expect(win).toBeVisible();
+  });
+
+  test('Maximize → Restore round-trip returns the window to its pre-max rect', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'About Cory');
+    const win = page.locator('section[aria-label="About Cory window"]');
+    const preMax = await win.boundingBox();
+    expect(preMax).toBeTruthy();
+
+    await page.locator('button[aria-label="Maximize About Cory"]').click();
+    const maxed = await win.boundingBox();
+    expect(maxed!.width).toBeGreaterThan(preMax!.width);
+    expect(maxed!.height).toBeGreaterThan(preMax!.height);
+
+    // After toggle, the button label flips to "Restore".
+    await page.locator('button[aria-label="Restore About Cory"]').click();
+    const restored = await win.boundingBox();
+    expect(Math.round(restored!.x)).toBe(Math.round(preMax!.x));
+    expect(Math.round(restored!.y)).toBe(Math.round(preMax!.y));
+    expect(Math.round(restored!.width)).toBe(Math.round(preMax!.width));
+    expect(Math.round(restored!.height)).toBe(Math.round(preMax!.height));
+  });
+
+  test('Layout persists across reload (localStorage blob survives)', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'Projects');
+    const win = page.locator('section[aria-label="Projects window"]');
+    await expect(win).toBeVisible();
+
+    const before = await page.evaluate(() => {
+      const raw = localStorage.getItem('cortechos:layout');
+      return raw ? JSON.parse(raw).state : null;
+    });
+    expect(before).toBeTruthy();
+    const projBefore = before.windows.find((w: { appId: string }) => w.appId === 'projects');
+    expect(projBefore).toBeTruthy();
+
+    await page.reload();
+    // hasBooted is persisted → no splash on reload.
+    await expect(page.locator('#ct-desktop')).toBeVisible({ timeout: 15_000 });
+    await expect(win).toBeVisible();
+
+    const after = await page.evaluate(() => {
+      const raw = localStorage.getItem('cortechos:layout');
+      return raw ? JSON.parse(raw).state : null;
+    });
+    const projAfter = after.windows.find((w: { appId: string }) => w.appId === 'projects');
+    expect(projAfter.x).toBe(projBefore.x);
+    expect(projAfter.y).toBe(projBefore.y);
+    expect(projAfter.w).toBe(projBefore.w);
+    expect(projAfter.h).toBe(projBefore.h);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
         "@playwright/test": "^1.59.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitest/coverage-v8": "^4.1.4",
         "happy-dom": "^20.9.0",
         "typescript": "^5.9.3",
@@ -481,6 +483,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2310,6 +2322,86 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3425,6 +3517,13 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -4536,6 +4635,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5740,6 +5849,41 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "astro": "astro",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
@@ -34,6 +35,8 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
     "@playwright/test": "^1.59.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitest/coverage-v8": "^4.1.4",
     "happy-dom": "^20.9.0",
     "typescript": "^5.9.3",

--- a/src/apps/iconUtils.test.tsx
+++ b/src/apps/iconUtils.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isValidElement } from 'react';
+import { renderIcon } from './iconUtils';
+
+describe('renderIcon', () => {
+  it('returns an emoji string unchanged', () => {
+    expect(renderIcon('🛡️')).toBe('🛡️');
+    expect(renderIcon('📁')).toBe('📁');
+  });
+
+  it('returns an <img> React element when the string starts with "/"', () => {
+    const node = renderIcon('/mark-sm.svg', 'h-6 w-6');
+    expect(isValidElement(node)).toBe(true);
+    // ReactElement shape inspection
+    const el = node as { type: string; props: { src: string; className?: string; alt?: string } };
+    expect(el.type).toBe('img');
+    expect(el.props.src).toBe('/mark-sm.svg');
+    expect(el.props.className).toBe('h-6 w-6');
+    expect(el.props.alt).toBe('');
+  });
+
+  it('passes non-string values through unchanged', () => {
+    const jsxNode = { type: 'svg', props: {} } as unknown;
+    expect(renderIcon(jsxNode)).toBe(jsxNode);
+    expect(renderIcon(null)).toBeNull();
+    expect(renderIcon(undefined)).toBeUndefined();
+  });
+
+  it('non-path strings (e.g. "http://...") are returned as-is, not wrapped in <img>', () => {
+    // Only paths starting with "/" are promoted to <img>. URLs are treated as text.
+    expect(renderIcon('https://example.com/x.svg')).toBe('https://example.com/x.svg');
+  });
+});

--- a/src/apps/registry.test.ts
+++ b/src/apps/registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { apps } from './registry';
+
+describe('app registry invariants', () => {
+  it('ids are unique', () => {
+    const ids = apps.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every app has the required core fields', () => {
+    for (const a of apps) {
+      expect(a.id, 'id').toBeTruthy();
+      expect(a.name, `${a.id} name`).toBeTruthy();
+      expect(a.description, `${a.id} description`).toBeTruthy();
+      expect(a.icon, `${a.id} icon`).toBeDefined();
+      expect(['iframe', 'native'], `${a.id} type`).toContain(a.type);
+      expect(a.defaultSize.w, `${a.id} defaultSize.w`).toBeGreaterThan(0);
+      expect(a.defaultSize.h, `${a.id} defaultSize.h`).toBeGreaterThan(0);
+    }
+  });
+
+  it('iframe apps have a https:// url and no component loader', () => {
+    for (const a of apps.filter((a) => a.type === 'iframe')) {
+      expect(a.url, `${a.id} url`).toBeTruthy();
+      expect(a.url, `${a.id} url`).toMatch(/^https:\/\//);
+      expect(a.component, `${a.id} should not have a component`).toBeUndefined();
+    }
+  });
+
+  it('native apps have a component loader and no url', () => {
+    for (const a of apps.filter((a) => a.type === 'native')) {
+      expect(typeof a.component, `${a.id} component`).toBe('function');
+      expect(a.url, `${a.id} should not have a url`).toBeUndefined();
+    }
+  });
+
+  it('defaultSize dominates minSize when both present', () => {
+    for (const a of apps) {
+      if (!a.minSize) continue;
+      expect(a.defaultSize.w, `${a.id} width`).toBeGreaterThanOrEqual(a.minSize.w);
+      expect(a.defaultSize.h, `${a.id} height`).toBeGreaterThanOrEqual(a.minSize.h);
+    }
+  });
+
+  it('githubRepo (when present) matches owner/repo format', () => {
+    for (const a of apps) {
+      if (a.githubRepo === undefined) continue;
+      expect(a.githubRepo, `${a.id}`).toMatch(/^[\w.-]+\/[\w.-]+$/);
+    }
+  });
+
+  it('paid flag is only ever set to true (never false)', () => {
+    for (const a of apps) {
+      if ('paid' in a && a.paid !== undefined) {
+        expect(a.paid, `${a.id} paid`).toBe(true);
+      }
+    }
+  });
+
+  it('allowMultiple native apps use app.id as their window id (singleton contract)', () => {
+    // The store assigns instanceId = app.id when allowMultiple === false.
+    // Having duplicate singleton ids across the registry would collide; verify.
+    const singletonIds = apps
+      .filter((a) => a.allowMultiple === false)
+      .map((a) => a.id);
+    expect(new Set(singletonIds).size).toBe(singletonIds.length);
+  });
+});

--- a/src/components/os/Launcher.test.tsx
+++ b/src/components/os/Launcher.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Launcher, matches } from './Launcher';
+import { apps, type AppManifest } from '../../apps/registry';
+import { useOS } from './store';
+
+function makeApp(overrides: Partial<AppManifest> = {}): AppManifest {
+  return {
+    id: 'test-app',
+    name: 'Test App',
+    description: 'a test',
+    icon: 'i',
+    type: 'native',
+    component: () => Promise.resolve({ default: () => null as any }),
+    defaultSize: { w: 400, h: 300 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useOS.setState({ windows: [], focusedId: null, nextZ: 1, hasBooted: false });
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('matches (search predicate)', () => {
+  it('empty query matches every app', () => {
+    expect(matches(makeApp({ id: 'foo', name: 'Foo', description: 'bar' }), '')).toBe(true);
+  });
+
+  it('matches on name, description, and id (case-insensitive)', () => {
+    const app = makeApp({ id: 'dmarc-mx', name: 'dmarc.mx', description: 'email security' });
+    expect(matches(app, 'dmarc')).toBe(true);
+    expect(matches(app, 'DMARC')).toBe(true);
+    expect(matches(app, 'email')).toBe(true);
+    expect(matches(app, 'mx')).toBe(true);
+  });
+
+  it('non-matching query returns false', () => {
+    const app = makeApp({ id: 'foo', name: 'Foo', description: 'bar' });
+    expect(matches(app, 'nope')).toBe(false);
+  });
+});
+
+describe('<Launcher />', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(<Launcher open={false} onClose={() => {}} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders every registered app when the query is empty', () => {
+    render(<Launcher open={true} onClose={() => {}} />);
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(apps.length);
+  });
+
+  it('filters the list as the user types', async () => {
+    const user = userEvent.setup();
+    render(<Launcher open={true} onClose={() => {}} />);
+    const input = screen.getByRole('textbox', { name: /search apps/i });
+    await user.type(input, 'dmarc');
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]!.textContent).toMatch(/dmarc\.mx/i);
+  });
+
+  it('ArrowDown / ArrowUp moves aria-selected across results', async () => {
+    const user = userEvent.setup();
+    render(<Launcher open={true} onClose={() => {}} />);
+    const options = screen.getAllByRole('option');
+    expect(options[0]!.getAttribute('aria-selected')).toBe('true');
+
+    await user.keyboard('{ArrowDown}');
+    expect(options[1]!.getAttribute('aria-selected')).toBe('true');
+    expect(options[0]!.getAttribute('aria-selected')).toBe('false');
+
+    await user.keyboard('{ArrowUp}');
+    expect(options[0]!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('ArrowUp at the top and ArrowDown past the bottom clamp (no wrap)', async () => {
+    const user = userEvent.setup();
+    render(<Launcher open={true} onClose={() => {}} />);
+    const options = screen.getAllByRole('option');
+
+    await user.keyboard('{ArrowUp}');
+    expect(options[0]!.getAttribute('aria-selected')).toBe('true');
+
+    for (let i = 0; i < options.length; i++) await user.keyboard('{ArrowDown}');
+    const last = options[options.length - 1]!;
+    expect(last.getAttribute('aria-selected')).toBe('true');
+
+    await user.keyboard('{ArrowDown}');
+    expect(last.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('Enter opens the selected app via the store and calls onClose', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    const openAppSpy = vi.spyOn(useOS.getState(), 'openApp');
+
+    render(<Launcher open={true} onClose={onClose} />);
+    await user.keyboard('{Enter}');
+
+    expect(openAppSpy).toHaveBeenCalledTimes(1);
+    expect(openAppSpy.mock.calls[0]![0]!.id).toBe(apps[0]!.id);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Clicking an option opens it and closes the launcher', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Launcher open={true} onClose={onClose} />);
+    const options = screen.getAllByRole('option');
+    await user.click(options[2]!);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(useOS.getState().windows).toHaveLength(1);
+    expect(useOS.getState().windows[0]!.appId).toBe(apps[2]!.id);
+  });
+
+  it('Escape closes the launcher', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Launcher open={true} onClose={onClose} />);
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Tab keeps focus on the search input (focus trap)', async () => {
+    const user = userEvent.setup();
+
+    render(<Launcher open={true} onClose={() => {}} />);
+    const input = screen.getByRole('textbox', { name: /search apps/i }) as HTMLInputElement;
+    // requestAnimationFrame focus is racy under happy-dom — force-focus for determinism.
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    await user.keyboard('{Tab}');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('backdrop click closes the launcher', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Launcher open={true} onClose={onClose} />);
+    const dialog = screen.getByRole('dialog', { name: /app launcher/i });
+    await user.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking an inner <li> (not the button) does not bubble up to backdrop close', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Launcher open={true} onClose={onClose} />);
+    const listbox = screen.getByRole('listbox');
+    const firstLi = within(listbox).getAllByRole('option')[0]!.parentElement!; // the <li>
+    await user.click(firstLi);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders an empty-state message when no apps match the query', async () => {
+    const user = userEvent.setup();
+    render(<Launcher open={true} onClose={() => {}} />);
+    const input = screen.getByRole('textbox', { name: /search apps/i });
+    await user.type(input, 'zzzz-nothing-matches-zzzz');
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getByText(/no apps match/i)).not.toBeNull();
+  });
+});

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -8,7 +8,7 @@ type Props = {
   onClose: () => void;
 };
 
-function matches(app: AppManifest, q: string) {
+export function matches(app: AppManifest, q: string) {
   if (!q) return true;
   const hay = `${app.name} ${app.description} ${app.id}`.toLowerCase();
   return hay.includes(q.toLowerCase());

--- a/src/components/os/store.test.ts
+++ b/src/components/os/store.test.ts
@@ -195,4 +195,96 @@ describe('persistence partialize', () => {
     expect(Object.keys(slice).sort()).toEqual(['hasBooted', 'nextZ', 'windows']);
     expect(slice).not.toHaveProperty('focusedId');
   });
+
+  it('openApp writes a partialized slice (no focusedId) to localStorage', () => {
+    useOS.getState().openApp(makeApp({ id: 'a' }));
+    useOS.setState({ hasBooted: true });
+
+    const raw = localStorage.getItem('cortechos:layout');
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state).not.toHaveProperty('focusedId');
+    expect(parsed.state.windows).toHaveLength(1);
+    expect(parsed.state.hasBooted).toBe(true);
+  });
+
+  it('rehydrate loads a preset localStorage blob and leaves focusedId null', async () => {
+    // Preset a saved layout directly; bypass openApp so the in-memory write
+    // doesn't re-trigger persistence.
+    const blob = {
+      state: {
+        windows: [
+          {
+            id: 'preset',
+            appId: 'preset',
+            title: 'Preset',
+            icon: 'i',
+            x: 100,
+            y: 200,
+            w: 400,
+            h: 300,
+            z: 5,
+            minimized: false,
+            maximized: false,
+          },
+        ],
+        nextZ: 6,
+        hasBooted: true,
+      },
+      version: 1,
+    };
+    localStorage.setItem('cortechos:layout', JSON.stringify(blob));
+
+    await useOS.persist.rehydrate();
+
+    const after = useOS.getState();
+    expect(after.windows).toHaveLength(1);
+    expect(after.windows[0]!.id).toBe('preset');
+    expect(after.windows[0]!.x).toBe(100);
+    expect(after.nextZ).toBe(6);
+    expect(after.hasBooted).toBe(true);
+    expect(after.focusedId).toBeNull();
+  });
+});
+
+describe('cascade placement', () => {
+  it('9th window wraps back to INITIAL_OFFSET (count % 8)', () => {
+    // Use distinct singleton ids so instanceId == id and stays stable.
+    for (let i = 0; i < 9; i++) {
+      useOS.getState().openApp(makeApp({ id: `app-${i}` }));
+    }
+    const s = useOS.getState();
+    expect(s.windows).toHaveLength(9);
+    const ninth = s.windows[8]!;
+    expect(ninth.x).toBe(24);
+    expect(ninth.y).toBe(24);
+  });
+
+  it('cascade offset math: nth window (n<8) is at 24 + n*28', () => {
+    for (let i = 0; i < 4; i++) {
+      useOS.getState().openApp(makeApp({ id: `app-${i}` }));
+    }
+    const s = useOS.getState();
+    for (let i = 0; i < 4; i++) {
+      expect(s.windows[i]!.x).toBe(24 + i * 28);
+      expect(s.windows[i]!.y).toBe(24 + i * 28);
+    }
+  });
+});
+
+describe('resetLayout', () => {
+  it('clears windows and focusedId, resets nextZ to 1, preserves hasBooted', () => {
+    useOS.getState().openApp(makeApp({ id: 'a' }));
+    useOS.getState().openApp(makeApp({ id: 'b' }));
+    useOS.setState({ hasBooted: true });
+    expect(useOS.getState().nextZ).toBeGreaterThan(1);
+
+    useOS.getState().resetLayout();
+
+    const s = useOS.getState();
+    expect(s.windows).toEqual([]);
+    expect(s.focusedId).toBeNull();
+    expect(s.nextZ).toBe(1);
+    expect(s.hasBooted).toBe(true);
+  });
 });

--- a/src/hooks/useProjects.test.ts
+++ b/src/hooks/useProjects.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { relativeTime } from './useProjects';
+
+describe('relativeTime', () => {
+  const NOW = new Date('2026-04-14T12:00:00Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "today" for timestamps less than ~12h old', () => {
+    // 6h earlier → 0.25d → Math.round → 0 → "today"
+    expect(relativeTime('2026-04-14T06:00:00Z')).toBe('today');
+  });
+
+  it('returns "Nd ago" for days under 30', () => {
+    const t = new Date(NOW);
+    t.setDate(t.getDate() - 5);
+    expect(relativeTime(t.toISOString())).toBe('5d ago');
+  });
+
+  it('returns "Nmo ago" for days 30..364', () => {
+    const t = new Date(NOW);
+    t.setDate(t.getDate() - 90);
+    expect(relativeTime(t.toISOString())).toBe('3mo ago');
+  });
+
+  it('returns "Ny ago" for 365+ days', () => {
+    const t = new Date(NOW);
+    t.setFullYear(t.getFullYear() - 2);
+    expect(relativeTime(t.toISOString())).toBe('2y ago');
+  });
+
+  it('30-day boundary: 29 days → "29d ago", 30 days → "1mo ago"', () => {
+    const t29 = new Date(NOW);
+    t29.setDate(t29.getDate() - 29);
+    expect(relativeTime(t29.toISOString())).toBe('29d ago');
+
+    const t30 = new Date(NOW);
+    t30.setDate(t30.getDate() - 30);
+    expect(relativeTime(t30.toISOString())).toBe('1mo ago');
+  });
+
+  it('365-day boundary: ~11mo → "Nmo ago", 365 days → "1y ago"', () => {
+    const t364 = new Date(NOW);
+    t364.setDate(t364.getDate() - 364);
+    // 364/30 ≈ 12.13 → rounds to 12
+    expect(relativeTime(t364.toISOString())).toBe('12mo ago');
+
+    const t365 = new Date(NOW);
+    t365.setDate(t365.getDate() - 365);
+    expect(relativeTime(t365.toISOString())).toBe('1y ago');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,16 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     exclude: ['node_modules/**', 'dist/**', 'e2e/**', '.worktrees/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/pages/**',
+        'src/layouts/**',
+        'src/env.d.ts',
+      ],
+    },
   },
 });


### PR DESCRIPTION
## Summary

- **Vitest: 15 → 53 tests** across 6 files. Added unit tests for pure helpers (`relativeTime`, `renderIcon`, registry invariants), extended store tests (cascade wrap, persistence rehydrate, `resetLayout` contract), and added a Launcher component suite covering keyboard nav, focus trap, backdrop behavior, and the empty state.
- **Playwright: +4 E2E scenarios** (`desktop interactions` describe) covering behaviors documented in `docs/architecture.md` that weren't verified: ⌘W closes focused window, minimize → taskbar pill restore, maximize round-trip preserves pre-max rect, and layout persists across `page.reload()`.
- **Coverage reporting enabled** (`@vitest/coverage-v8` was already in devDeps but unused). `npm run test:coverage` now outputs text + HTML. No thresholds yet — baseline first.

## Why

Several contracts called out in `docs/architecture.md` — keyboard shortcuts, cascade wrap, layout persistence, launcher focus trap — had no automated coverage. Registry invariants (unique ids, iframe/native shape, paid flag) are the public API for adding apps, and one bad entry silently breaks the launcher. Closing these gaps prevents regressions without chasing a coverage percentage.

## Notable decisions

- **Scope guard**: intentionally skipped unit tests for `Window`, `Desktop`, `Taskbar`, `OSShell`, `BootSplash` — they're covered end-to-end by Playwright, and unit-testing `react-rnd` in happy-dom is low-ROI.
- **Persistence test**: split into (a) "openApp writes partialized slice" and (b) "preset localStorage → rehydrate" to avoid a zustand-persist pitfall where stomping in-memory state re-triggers the write and wipes the blob before rehydrate reads it.
- **Launcher test setup**: added `afterEach(cleanup)` since RTL doesn't auto-cleanup with vitest by default.
- **`matches()` export**: small refactor in `Launcher.tsx` so the search predicate can be unit-tested in isolation.
- **No threshold enforcement**: baseline is 26% overall statements; `store.ts` at 95%, `Launcher.tsx` at 100%. Thresholds should land in a follow-up once we know what's realistic.

## Test plan

- [x] `npm test` — 53/53 pass (311 ms → 670 ms)
- [x] `npm run test:coverage` — reports generated, Launcher/store/registry/iconUtils/useProjects helper all well covered
- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm run test:e2e --grep-invert iframe` — all 6 pass (mobile fallback, golden path, 4 new desktop interactions)
- [ ] `npm run test:e2e` (full, including iframe) — hits external services; recommend running once in CI
- [ ] Manual sanity: ⌘K / ⌘W / arrow keys in launcher behave as tests assert

🤖 Generated with [Claude Code](https://claude.com/claude-code)