### PR TITLE
feat: publish /rss.xml for projects (closes #2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
+        "@astrojs/rss": "^4.0.18",
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -209,6 +210,17 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1582,6 +1594,18 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
@@ -3799,6 +3823,42 @@
         "fast-string-width": "^1.1.0"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5727,6 +5787,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -6506,6 +6581,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.3",
+    "@astrojs/rss": "^4.0.18",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -24,6 +24,7 @@ const meta = description ?? 'Cortech is the work of Schmug — a small studio of
 		<title>{fullTitle}</title>
 		<meta name="description" content={meta} />
 		{canonical && <link rel="canonical" href={canonical} />}
+		<link rel="alternate" type="application/rss+xml" title="Cortech" href="/rss.xml" />
 		<meta property="og:title" content={fullTitle} />
 		<meta property="og:description" content={meta} />
 		<meta property="og:type" content="website" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,6 +17,7 @@ const flagships = apps.filter((a) => a.type === 'iframe');
 		<title>Cortech — Schmug</title>
 		<meta name="description" content="Cortech is the work of Schmug — a small studio of one building email-security tools, contact-card utilities, AI tooling, and playful experiments. Boot into CortechOS." />
 		<link rel="canonical" href="https://cortech.online/" />
+		<link rel="alternate" type="application/rss+xml" title="Cortech" href="/rss.xml" />
 		<meta property="og:title" content="Cortech — Schmug" />
 		<meta property="og:description" content="CortechOS — a tiny desktop that showcases each of my projects as a live, openable window." />
 		<meta property="og:type" content="website" />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,21 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { fetchOriginalRepos } from '../lib/github';
+
+export async function GET(context: APIContext) {
+  const repos = await fetchOriginalRepos('schmug');
+  return rss({
+    title: 'Cortech — Cory Schmug',
+    description: 'Small, useful things built at cortech.online',
+    site: context.site!,
+    items: repos.slice(0, 40).map((r) => ({
+      title: r.name,
+      description: r.description ?? '',
+      link: r.html_url,
+      pubDate: new Date(r.updated_at),
+    })),
+    customData: '<language>en-us</language>',
+  });
+}
+
+export const prerender = true;


### PR DESCRIPTION
## Summary

- Add RSS feed at `/rss.xml` using `@astrojs/rss`, reusing the existing `fetchOriginalRepos()` data path
- Feed includes top 40 non-fork, non-archived repos sorted by `updated_at`
- Wire `<link rel="alternate">` autodiscovery in both `Base.astro` and `index.astro`

## Changes

| File | What |
|------|------|
| `package.json` | Add `@astrojs/rss` dependency |
| `src/pages/rss.xml.ts` | New — RSS endpoint (prerendered at build time) |
| `src/layouts/Base.astro` | Add feed autodiscovery link |
| `src/pages/index.astro` | Add feed autodiscovery link |

## Test plan

- [x] `npm run build` — succeeds, `dist/rss.xml` exists with valid XML
- [x] `npm test` — 57/57 tests pass
- [x] `npm run typecheck` — 0 errors
- [x] Autodiscovery `<link>` present in `dist/index.html`, `dist/about/index.html`, `dist/projects/index.html`
- [ ] After deploy: `curl -I https://cortech.online/rss.xml` returns 200 + `application/rss+xml`
- [ ] Feed validates at https://validator.w3.org/feed/
- [ ] Feed reader (NetNewsWire/Feedly) auto-discovers from `cortech.online`
- [ ] donthype.me can parse and display the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)