### PR TITLE
Remove paid tags from dashboard apps

### DIFF
--- a/src/apps/registry.test.ts
+++ b/src/apps/registry.test.ts
@@ -49,14 +49,6 @@ describe('app registry invariants', () => {
     }
   });
 
-  it('paid flag is only ever set to true (never false)', () => {
-    for (const a of apps) {
-      if ('paid' in a && a.paid !== undefined) {
-        expect(a.paid, `${a.id} paid`).toBe(true);
-      }
-    }
-  });
-
   it('allowMultiple native apps use app.id as their window id (singleton contract)', () => {
     // The store assigns instanceId = app.id when allowMultiple === false.
     // Having duplicate singleton ids across the registry would collide; verify.

--- a/src/apps/registry.ts
+++ b/src/apps/registry.ts
@@ -12,7 +12,6 @@ export type AppManifest = {
   minSize?: { w: number; h: number };
   allowMultiple?: boolean;
   githubRepo?: string;
-  paid?: boolean;
 };
 
 export const apps: AppManifest[] = [
@@ -26,7 +25,6 @@ export const apps: AppManifest[] = [
     defaultSize: { w: 960, h: 680 },
     minSize: { w: 480, h: 360 },
     githubRepo: 'schmug/dmarcheck',
-    paid: true,
   },
   {
     id: 'donthype-me',
@@ -37,7 +35,6 @@ export const apps: AppManifest[] = [
     url: 'https://donthype.me',
     defaultSize: { w: 960, h: 680 },
     githubRepo: 'schmug/donthype-me',
-    paid: true,
   },
   {
     id: 'apartment-stager',
@@ -48,7 +45,6 @@ export const apps: AppManifest[] = [
     url: 'https://apartment-stager.pages.dev/',
     defaultSize: { w: 960, h: 680 },
     githubRepo: 'schmug/apartment-stager',
-    paid: true,
   },
   {
     id: 'qr-me',

--- a/src/components/mobile/HomeScreen.tsx
+++ b/src/components/mobile/HomeScreen.tsx
@@ -38,11 +38,6 @@ function AppTile({ app, onOpen }: TileProps) {
         <span aria-hidden="true" className="flex items-center justify-center">
           {renderIcon(app.icon, 'h-8 w-8')}
         </span>
-        {app.paid && (
-          <span className="absolute -top-1 -right-1 rounded-full bg-[var(--color-amber)] px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider text-[var(--color-void)] shadow">
-            paid
-          </span>
-        )}
       </span>
       <span className="max-w-full truncate text-[11px] font-medium text-[var(--color-text)]">
         {app.name}

--- a/src/components/os/Desktop.tsx
+++ b/src/components/os/Desktop.tsx
@@ -64,9 +64,6 @@ export function Desktop() {
             <span className="line-clamp-2 text-xs font-medium text-[var(--color-text)]">
               {app.name}
             </span>
-            {app.paid && (
-              <span className="font-mono text-[9px] uppercase tracking-wider text-[var(--color-amber)]">paid</span>
-            )}
           </button>
         ))}
       </div>

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -116,7 +116,6 @@ export function Launcher({ open, onClose }: Props) {
                 <span className="flex-1 min-w-0">
                   <span className="flex items-center gap-2">
                     <span className="font-medium">{app.name}</span>
-                    {app.paid && <span className="rounded bg-[var(--color-amber)]/20 px-1 font-mono text-[9px] uppercase tracking-wider">paid</span>}
                     <span className="font-mono text-[10px] text-[var(--color-muted)]">/{app.id}</span>
                   </span>
                   <span className="mt-0.5 block truncate text-xs text-[var(--color-muted)]">{app.description}</span>

--- a/src/components/os/apps/SupportApp.tsx
+++ b/src/components/os/apps/SupportApp.tsx
@@ -2,7 +2,7 @@ import { apps } from '../../../apps/registry';
 import { renderIcon } from '../../../apps/iconUtils';
 
 export default function SupportApp() {
-  const paidApps = apps.filter((a) => a.paid);
+  const flagships = apps.filter((a) => a.type === 'iframe');
 
   return (
     <div className="h-full overflow-y-auto bg-[var(--color-void)] px-7 py-6 text-[var(--color-text)]">
@@ -55,7 +55,7 @@ export default function SupportApp() {
       <section className="mt-8">
         <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-[var(--color-muted)]">What your support funds</div>
         <ul className="mt-3 grid gap-2 text-xs">
-          {paidApps.map((app) => (
+          {flagships.map((app) => (
             <li key={app.id} className="flex items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 px-3 py-2">
               <span aria-hidden="true" className="text-base">{renderIcon(app.icon, 'h-4 w-4')}</span>
               <div className="min-w-0 flex-1">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,7 +69,7 @@ const flagships = apps.filter((a) => a.type === 'iframe');
 										? <img src={app.icon} alt="" class="h-6 w-6" />
 										: <span class="text-xl">{app.icon}</span>}
 									<a href={app.url} rel="noopener" class="font-medium text-[var(--color-text)] hover:text-[var(--color-amber)]">{app.name}</a>
-									{app.paid && <span class="rounded bg-[var(--color-amber)]/15 px-1.5 py-0.5 font-mono text-[10px] uppercase text-[var(--color-amber)]">paid</span>}
+
 								</div>
 								<p class="mt-1 text-sm text-[var(--color-dim)]">{app.description}</p>
 							</li>


### PR DESCRIPTION
## Summary
- Removes the `paid?: boolean` property from `AppManifest` and all three `paid: true` entries (dmarc.mx, donthype.me, apartment-stager)
- Deletes amber "paid" badge rendering from Desktop, Launcher, HomeScreen (mobile), and the SSR fallback in index.astro
- Updates SupportApp "What your support funds" section to list all flagship (iframe) apps instead of filtering by the removed `paid` flag
- Removes the now-unnecessary `paid` flag test from registry.test.ts

## Test plan
- [x] All 41 project tests pass
- [x] `grep` confirms zero `paid` references remain in `src/`
- [ ] Visual check: desktop icons, launcher search, mobile home screen, and SSR fallback no longer show "paid" badges
- [ ] SupportApp still lists all four flagship products

🤖 Generated with [Claude Code](https://claude.com/claude-code)