### PR TITLE
feat(about): surface RSS feed with a visible icon card

### DIFF
--- a/src/components/os/apps/AboutApp.tsx
+++ b/src/components/os/apps/AboutApp.tsx
@@ -39,12 +39,28 @@ export default function AboutApp() {
         </ul>
       </section>
 
-      <section className="mt-6 grid gap-2 text-xs sm:grid-cols-3">
+      <section className="mt-6 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
         <LinkCard label="GitHub" href="https://github.com/schmug" value="github.com/schmug" />
         <LinkCard label="LinkedIn" href="https://www.linkedin.com/in/cory-rankin/" value="linkedin.com/in/cory-rankin" />
         <LinkCard label="Sponsor" href="https://github.com/sponsors/schmug" value="github.com/sponsors/schmug" />
+        <LinkCard label="RSS" href="/rss.xml" value="cortech.online/rss.xml" icon={<RssIcon />} external={false} />
       </section>
     </div>
+  );
+}
+
+function RssIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="h-3.5 w-3.5 text-[var(--color-amber)]"
+      fill="currentColor"
+    >
+      <path d="M4 4a16 16 0 0 1 16 16h-3A13 13 0 0 0 4 7V4z" />
+      <path d="M4 10a10 10 0 0 1 10 10h-3a7 7 0 0 0-7-7v-3z" />
+      <circle cx="6" cy="18" r="2" />
+    </svg>
   );
 }
 
@@ -60,16 +76,32 @@ function FocusRow({ badge, title, note }: { badge: string; title: string; note: 
   );
 }
 
-function LinkCard({ label, href, value }: { label: string; href: string; value: string }) {
+function LinkCard({
+  label,
+  href,
+  value,
+  icon,
+  external = true,
+}: {
+  label: string;
+  href: string;
+  value: string;
+  icon?: React.ReactNode;
+  external?: boolean;
+}) {
   return (
     <a
       href={href}
-      target="_blank"
-      rel="noopener"
+      {...(external ? { target: '_blank', rel: 'noopener' } : {})}
       className="group rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-3 transition hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]"
     >
-      <div className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-muted)]">{label}</div>
-      <div className="mt-0.5 font-mono text-xs text-[var(--color-text)] group-hover:text-[var(--color-amber)]">{value} ↗</div>
+      <div className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider text-[var(--color-muted)]">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="mt-0.5 font-mono text-xs text-[var(--color-text)] group-hover:text-[var(--color-amber)]">
+        {value} {external ? '↗' : '→'}
+      </div>
     </a>
   );
 }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,7 +28,7 @@ import Base from '../layouts/Base.astro';
 			</p>
 		</div>
 
-		<div class="mt-10 grid gap-3 text-sm sm:grid-cols-2">
+		<div class="mt-10 grid gap-3 text-sm sm:grid-cols-3">
 			<a href="https://github.com/schmug" rel="noopener" class="rounded-[var(--ct-radius)] border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-4 transition hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]">
 				<div class="font-mono text-[11px] uppercase tracking-wider text-[var(--color-muted)]">GitHub</div>
 				<div class="mt-1 text-[var(--color-text)]">github.com/schmug</div>
@@ -36,6 +36,17 @@ import Base from '../layouts/Base.astro';
 			<a href="https://github.com/sponsors/schmug" rel="noopener" class="rounded-[var(--ct-radius)] border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-4 transition hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]">
 				<div class="font-mono text-[11px] uppercase tracking-wider text-[var(--color-muted)]">Sponsor</div>
 				<div class="mt-1 text-[var(--color-text)]">github.com/sponsors/schmug</div>
+			</a>
+			<a href="/rss.xml" class="rounded-[var(--ct-radius)] border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-4 transition hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]">
+				<div class="flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wider text-[var(--color-muted)]">
+					<svg viewBox="0 0 24 24" aria-hidden="true" class="h-3.5 w-3.5 text-[var(--color-amber)]" fill="currentColor">
+						<path d="M4 4a16 16 0 0 1 16 16h-3A13 13 0 0 0 4 7V4z" />
+						<path d="M4 10a10 10 0 0 1 10 10h-3a7 7 0 0 0-7-7v-3z" />
+						<circle cx="6" cy="18" r="2" />
+					</svg>
+					<span>RSS</span>
+				</div>
+				<div class="mt-1 text-[var(--color-text)]">cortech.online/rss.xml</div>
 			</a>
 		</div>
 


### PR DESCRIPTION
## Summary

PR #18 shipped `/rss.xml` but only wired `<link rel=\"alternate\">` autodiscovery in `<head>`, leaving no human-visible entry point — visitors could not discover or subscribe to the feed without a feed reader. This adds an icon-first RSS card to both About surfaces.

## Changes

| File | What |
|------|------|
| `src/components/os/apps/AboutApp.tsx` | Add 4th `LinkCard` for RSS with an inline amber-tinted SVG glyph. Extend `LinkCard` to accept an optional `icon` and an `external` flag so the same-origin RSS link uses `→` instead of `↗` and omits `target=\"_blank\"`. Grid bumped to `sm:grid-cols-2 lg:grid-cols-4`. |
| `src/pages/about.astro` | Add 3rd anchor card with the same inline RSS SVG. Grid bumped to `sm:grid-cols-3`. |

Autodiscovery `<link>` tags in `Base.astro` and `index.astro` remain untouched — they serve feed readers and are orthogonal to the visible UI.

## Design notes

- Inline SVG, not a new `public/rss.svg` asset: two usages, 16×16, themable via `currentColor`, no extra request.
- Duplicated rather than abstracted across Astro + React surfaces — two call sites doesn't justify a shared component.
- Icon is `aria-hidden`; the visible \"RSS\" label provides the accessible name.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 56/56 pass
- [x] `npm run build` — succeeds; `dist/about/index.html` contains the visible RSS card AND still has the `<link rel=\"alternate\" type=\"application/rss+xml\">` autodiscovery tag
- [ ] After deploy: open `cortech.online/about` and the OS-shell About window, confirm the RSS card renders with icon and opens `/rss.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)