### PR TITLE
refactor: reference site owner as Schmug instead of Cory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The portfolio at [cortech.online](https://cortech.online) — an Astro-rendered landing that hydrates into a tiny desktop OS where each window is one of my projects. Mobile viewport falls back to a vertical card grid.
 
-![CortechOS desktop with the About Cory window open](docs/screenshot-desktop.png)
+![CortechOS desktop with the About Schmug window open](docs/screenshot-desktop.png)
 
 > Animated demo: [`docs/screenshot-desktop.gif`](docs/screenshot-desktop.gif) — boot → ⌘K launcher → open Projects → drag.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ type AppManifest = {
 
 **Iframe apps** (4): `dmarc.mx`, `donthype.me`, `apartment-stager`, `q-r.contact`. Hosted elsewhere; embedded as-is. Each must allow framing (no `X-Frame-Options: DENY`, no restrictive CSP `frame-ancestors`) — the iframe-embed Playwright suite enforces this.
 
-**Native apps** (3): `About Cory`, `Support`, `Projects`. Each is a lazy-imported React component under `src/components/os/apps/`.
+**Native apps** (3): `About Schmug`, `Support`, `Projects`. Each is a lazy-imported React component under `src/components/os/apps/`.
 
 To **add an app**: append one entry to the array. No other code changes needed — the launcher, desktop icons, and taskbar pick it up automatically.
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -82,12 +82,12 @@ test.describe('desktop golden path', () => {
     await page.screenshot({ path: testInfo.outputPath('1-booted.png') });
 
     // About auto-opens on first boot; clicking the icon focuses the singleton.
-    await page.locator('button[aria-label="Open About Cory"]').click();
-    await expect(page.locator('section[aria-label="About Cory window"]')).toBeVisible();
+    await page.locator('button[aria-label="Open About Schmug"]').click();
+    await expect(page.locator('section[aria-label="About Schmug window"]')).toBeVisible();
     await page.screenshot({ path: testInfo.outputPath('2-about-open.png') });
 
     // Brand-mark regression: AboutApp header renders the full mark as an <img>, not an emoji.
-    const aboutAvatar = page.locator('section[aria-label="About Cory window"] img[src="/mark.svg"]');
+    const aboutAvatar = page.locator('section[aria-label="About Schmug window"] img[src="/mark.svg"]');
     await expect(aboutAvatar).toBeVisible();
 
     await page.locator('button[aria-label="Open launcher"]').click();
@@ -149,18 +149,18 @@ test.describe('desktop interactions', () => {
 
   test('Maximize → Restore round-trip returns the window to its pre-max rect', async ({ page }) => {
     await bootDesktop(page);
-    await openApp(page, 'About Cory');
-    const win = page.locator('section[aria-label="About Cory window"]');
+    await openApp(page, 'About Schmug');
+    const win = page.locator('section[aria-label="About Schmug window"]');
     const preMax = await win.boundingBox();
     expect(preMax).toBeTruthy();
 
-    await page.locator('button[aria-label="Maximize About Cory"]').click();
+    await page.locator('button[aria-label="Maximize About Schmug"]').click();
     const maxed = await win.boundingBox();
     expect(maxed!.width).toBeGreaterThan(preMax!.width);
     expect(maxed!.height).toBeGreaterThan(preMax!.height);
 
     // After toggle, the button label flips to "Restore".
-    await page.locator('button[aria-label="Restore About Cory"]').click();
+    await page.locator('button[aria-label="Restore About Schmug"]').click();
     const restored = await win.boundingBox();
     expect(Math.round(restored!.x)).toBe(Math.round(preMax!.x));
     expect(Math.round(restored!.y)).toBe(Math.round(preMax!.y));
@@ -220,7 +220,7 @@ test.describe('mobile springboard', () => {
     // Dock shows 3 pinned apps (About, Support, Projects).
     const dockButtons = page.locator('nav[aria-label="Dock"] button');
     await expect(dockButtons).toHaveCount(3);
-    await expect(page.locator('nav[aria-label="Dock"] button[aria-label="Open About Cory"]')).toBeVisible();
+    await expect(page.locator('nav[aria-label="Dock"] button[aria-label="Open About Schmug"]')).toBeVisible();
     await expect(page.locator('nav[aria-label="Dock"] button[aria-label="Open Support"]')).toBeVisible();
     await expect(page.locator('nav[aria-label="Dock"] button[aria-label="Open Projects"]')).toBeVisible();
 

--- a/scripts/capture-screenshot.mjs
+++ b/scripts/capture-screenshot.mjs
@@ -31,7 +31,7 @@ await page.reload({ waitUntil: 'domcontentloaded' });
 await page.locator('[aria-label="CortechOS booting"]').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
 await page.keyboard.press('Space');
 await page.locator('[aria-label="CortechOS booting"]').waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
-await page.locator('section[aria-label="About Cory window"]').waitFor({ state: 'visible', timeout: 10_000 });
+await page.locator('section[aria-label="About Schmug window"]').waitFor({ state: 'visible', timeout: 10_000 });
 await page.waitForTimeout(400);
 
 await mkdir(dirname(OUT), { recursive: true });

--- a/src/apps/registry.ts
+++ b/src/apps/registry.ts
@@ -58,7 +58,7 @@ export const apps: AppManifest[] = [
   },
   {
     id: 'about',
-    name: 'About Cory',
+    name: 'About Schmug',
     description: 'Bio, what I build, how to reach me.',
     icon: '/mark-sm.svg',
     type: 'native',

--- a/src/components/os/apps/AboutApp.tsx
+++ b/src/components/os/apps/AboutApp.tsx
@@ -10,7 +10,7 @@ export default function AboutApp() {
         />
         <div>
           <div className="font-mono text-[11px] uppercase tracking-[0.3em] text-[var(--color-amber)]">About</div>
-          <h1 className="mt-1 font-[var(--font-display)] text-2xl font-semibold tracking-tight">Cory</h1>
+          <h1 className="mt-1 font-[var(--font-display)] text-2xl font-semibold tracking-tight">Schmug</h1>
           <p className="mt-1 text-sm text-[var(--color-muted)]">
             Indie builder · Cloudflare-native · studio-of-one
           </p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -12,7 +12,7 @@ import Base from '../layouts/Base.astro';
 			/>
 			<div>
 				<p class="font-mono text-[11px] uppercase tracking-[0.35em] text-[var(--color-amber)]">About</p>
-				<h1 class="mt-2 font-[var(--font-display)] text-3xl font-bold tracking-tight sm:text-4xl">Cory</h1>
+				<h1 class="mt-2 font-[var(--font-display)] text-3xl font-bold tracking-tight sm:text-4xl">Schmug</h1>
 			</div>
 		</div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ const flagships = apps.filter((a) => a.type === 'iframe');
 			<main class="mx-auto max-w-4xl px-6 py-16">
 				<p class="font-mono text-[11px] uppercase tracking-[0.35em] text-[var(--color-amber)]">CortechOS 1.0</p>
 				<h1 class="mt-4 font-[var(--font-display)] text-4xl font-bold tracking-tight sm:text-5xl">
-					Hi, I'm Cory. I build <span class="text-[var(--color-amber)]">small, useful things</span>.
+					I build <span class="text-[var(--color-amber)]">small, useful things</span>.
 				</h1>
 				<p class="mt-5 max-w-2xl text-lg text-[var(--color-dim)]">
 					Email security, contact-card utilities, AI tooling, and the occasional piece of generative art. Enable JavaScript to boot into <span class="font-mono text-[var(--color-amber)]">CortechOS</span> — a tiny desktop where you can open each project in a window.

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -5,7 +5,7 @@ import { fetchOriginalRepos } from '../lib/github';
 export async function GET(context: APIContext) {
   const repos = await fetchOriginalRepos('schmug');
   return rss({
-    title: 'Cortech — Cory Schmug',
+    title: 'Cortech — Schmug',
     description: 'Small, useful things built at cortech.online',
     site: context.site!,
     items: repos.slice(0, 40).map((r) => ({


### PR DESCRIPTION
## Summary

The RSS feed title surfaced as "Cortech — Cory Schmug" and the rest of the site was inconsistently mixed between the two names. Standardize on **Schmug** everywhere user-visible, with the LinkedIn link (handle `cory-rankin`) as the sole exception.

## Changes

- **RSS feed** ([src/pages/rss.xml.ts](src/pages/rss.xml.ts)) — title is now `Cortech — Schmug` (the trigger for this PR).
- **About page** ([src/pages/about.astro](src/pages/about.astro)) and **AboutApp window** ([src/components/os/apps/AboutApp.tsx](src/components/os/apps/AboutApp.tsx)) — `<h1>` reads `Schmug`.
- **Homepage hero** ([src/pages/index.astro](src/pages/index.astro)) — dropped the first-person greeting (`Hi, I'm Cory.`) entirely; `Hi, I'm Schmug.` reads oddly with a surname, so the hero now opens with `I build small, useful things.` The name still appears on `/about` and in the AboutApp.
- **App registry** ([src/apps/registry.ts](src/apps/registry.ts)) — app `name` is `About Schmug`. Aria-labels (dock / taskbar / window controls / mobile) interpolate `app.name`, so this single rename cascades through the UI.
- **e2e + screenshot script** ([e2e/smoke.spec.ts](e2e/smoke.spec.ts), [scripts/capture-screenshot.mjs](scripts/capture-screenshot.mjs)) — selectors updated to `About Schmug` to match the new aria-labels.
- **Docs** ([README.md](README.md), [docs/architecture.md](docs/architecture.md)) — references updated for consistency.

## Explicitly preserved

- LinkedIn `href` and displayed value at [src/components/os/apps/AboutApp.tsx:44](src/components/os/apps/AboutApp.tsx:44) keep `cory-rankin`.
- `docs/superpowers/specs/**` and `docs/superpowers/plans/**` — historical brainstorm/plan docs, not part of the live site.

## Test plan

- [x] `rg Cory src/` returns only the LinkedIn line
- [x] `npm run build` succeeds; built `dist/rss.xml` shows `<title>Cortech — Schmug</title>` and `dist/about/index.html` shows `<h1>...Schmug</h1>`
- [ ] CI: Playwright smoke suite passes with the renamed aria-labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)