### PR TITLE
feat(apps): surface more GitHub repos as desktop apps via data-driven list

### DIFF
--- a/src/apps/featuredRepos.test.ts
+++ b/src/apps/featuredRepos.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appIdForFeaturedRepo,
+  featuredRepos,
+  repoNameFromFullName,
+} from './featuredRepos';
+import { apps } from './registry';
+
+describe('featuredRepos config', () => {
+  it('every entry has a valid owner/repo fullName', () => {
+    for (const cfg of featuredRepos) {
+      expect(cfg.fullName, `fullName`).toMatch(/^[\w.-]+\/[\w.-]+$/);
+    }
+  });
+
+  it('fullNames are unique within the config', () => {
+    const names = featuredRepos.map((r) => r.fullName.toLowerCase());
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('derived app ids do not collide with static registry ids', () => {
+    const staticIds = new Set(apps.map((a) => a.id));
+    for (const cfg of featuredRepos) {
+      expect(staticIds.has(appIdForFeaturedRepo(cfg.fullName))).toBe(false);
+    }
+  });
+
+  it('manual entries provide a description and htmlUrl', () => {
+    for (const cfg of featuredRepos) {
+      if (!cfg.manual) continue;
+      expect(cfg.manual.description, `${cfg.fullName} description`).toBeTruthy();
+      expect(cfg.manual.htmlUrl, `${cfg.fullName} htmlUrl`).toMatch(/^https:\/\//);
+    }
+  });
+});
+
+describe('repoNameFromFullName', () => {
+  it('returns the segment after the last slash', () => {
+    expect(repoNameFromFullName('schmug/scubascore')).toBe('scubascore');
+  });
+
+  it('returns the input unchanged when no slash is present', () => {
+    expect(repoNameFromFullName('just-a-name')).toBe('just-a-name');
+  });
+});
+
+describe('appIdForFeaturedRepo', () => {
+  it('prefixes with gh: so it cannot collide with plain registry ids', () => {
+    expect(appIdForFeaturedRepo('schmug/scubascore')).toBe('gh:schmug/scubascore');
+  });
+});

--- a/src/apps/featuredRepos.ts
+++ b/src/apps/featuredRepos.ts
@@ -1,0 +1,53 @@
+export type FeaturedRepoManual = {
+  description: string;
+  language?: string;
+  htmlUrl: string;
+  homepage?: string;
+};
+
+export type FeaturedRepoConfig = {
+  fullName: string;
+  icon?: string;
+  manual?: FeaturedRepoManual;
+};
+
+export const featuredRepos: FeaturedRepoConfig[] = [
+  { fullName: 'schmug/scubascore', icon: '🤿' },
+  { fullName: 'schmug/FeedBat', icon: '🦇' },
+  { fullName: 'schmug/opml-backup', icon: '🗂️' },
+  { fullName: 'schmug/cupid', icon: '💘' },
+  { fullName: 'schmug/untitledgoogetool', icon: '🦢' },
+  {
+    fullName: 'schmug/school-calendar',
+    icon: '📅',
+    manual: {
+      description: 'Private tool for tracking school calendars.',
+      language: 'TypeScript',
+      htmlUrl: 'https://github.com/schmug/school-calendar',
+    },
+  },
+];
+
+export type FeaturedRepo = {
+  fullName: string;
+  name: string;
+  icon?: string;
+  description: string | null;
+  htmlUrl: string;
+  homepage: string | null;
+  language: string | null;
+  stargazersCount: number;
+  updatedAt: string | null;
+  fork: boolean;
+  archived: boolean;
+  private: boolean;
+};
+
+export function repoNameFromFullName(fullName: string): string {
+  const slash = fullName.lastIndexOf('/');
+  return slash === -1 ? fullName : fullName.slice(slash + 1);
+}
+
+export function appIdForFeaturedRepo(fullName: string): string {
+  return `gh:${fullName}`;
+}

--- a/src/apps/registry.test.ts
+++ b/src/apps/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { apps } from './registry';
+import { appIdForFeaturedRepo, featuredRepos } from './featuredRepos';
 
 describe('app registry invariants', () => {
   it('ids are unique', () => {
@@ -56,6 +57,13 @@ describe('app registry invariants', () => {
       .filter((a) => a.allowMultiple === false)
       .map((a) => a.id);
     expect(new Set(singletonIds).size).toBe(singletonIds.length);
+  });
+
+  it('static app ids do not collide with any featured-repo app id', () => {
+    const staticIds = new Set(apps.map((a) => a.id));
+    for (const cfg of featuredRepos) {
+      expect(staticIds.has(appIdForFeaturedRepo(cfg.fullName))).toBe(false);
+    }
   });
 
   it('blog app is registered as a singleton native app', () => {

--- a/src/apps/registry.ts
+++ b/src/apps/registry.ts
@@ -7,7 +7,8 @@ export type AppManifest = {
   icon: string | ReactNode;
   type: 'iframe' | 'native';
   url?: string;
-  component?: () => Promise<{ default: ComponentType }>;
+  component?: () => Promise<{ default: ComponentType<Record<string, unknown>> }>;
+  componentProps?: Record<string, unknown>;
   defaultSize: { w: number; h: number };
   minSize?: { w: number; h: number };
   allowMultiple?: boolean;

--- a/src/components/mobile/AppView.tsx
+++ b/src/components/mobile/AppView.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useEffect, useMemo, useState, type ComponentType } from 'react';
-import { apps } from '../../apps/registry';
+import { useAllApps } from '../../hooks/useAllApps';
 import { useMobile } from './store';
 import { StatusBar } from './StatusBar';
 
@@ -8,6 +8,7 @@ type Props = {
 };
 
 export function AppView({ appId }: Props) {
+  const apps = useAllApps();
   const closeApp = useMobile((s) => s.closeApp);
   const app = apps.find((a) => a.id === appId);
 
@@ -18,7 +19,7 @@ export function AppView({ appId }: Props) {
     return () => cancelAnimationFrame(raf);
   }, []);
 
-  const NativeComponent = useMemo<ComponentType | null>(() => {
+  const NativeComponent = useMemo<ComponentType<Record<string, unknown>> | null>(() => {
     if (!app || app.type !== 'native' || !app.component) return null;
     return lazy(app.component);
   }, [app]);
@@ -57,7 +58,7 @@ export function AppView({ appId }: Props) {
         ) : NativeComponent ? (
           <div className="h-full overflow-auto">
             <Suspense fallback={<NativeFallback />}>
-              <NativeComponent />
+              <NativeComponent {...(app.componentProps ?? {})} />
             </Suspense>
           </div>
         ) : null}

--- a/src/components/mobile/HomeScreen.tsx
+++ b/src/components/mobile/HomeScreen.tsx
@@ -1,8 +1,10 @@
-import { apps, type AppManifest } from '../../apps/registry';
+import { type AppManifest } from '../../apps/registry';
 import { renderIcon } from '../../apps/iconUtils';
+import { useAllApps } from '../../hooks/useAllApps';
 import { useMobile } from './store';
 
 export function HomeScreen() {
+  const apps = useAllApps();
   const openApp = useMobile((s) => s.openApp);
 
   return (

--- a/src/components/os/Desktop.tsx
+++ b/src/components/os/Desktop.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
-import { apps, type AppManifest } from '../../apps/registry';
+import { type AppManifest } from '../../apps/registry';
 import { renderIcon } from '../../apps/iconUtils';
+import { useAllApps } from '../../hooks/useAllApps';
 import { useOS } from './store';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 
 type MenuState = { x: number; y: number; app: AppManifest } | null;
 
 export function Desktop() {
+  const apps = useAllApps();
   const openApp = useOS((s) => s.openApp);
   const [menu, setMenu] = useState<MenuState>(null);
 

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { apps, type AppManifest } from '../../apps/registry';
+import { type AppManifest } from '../../apps/registry';
 import { renderIcon } from '../../apps/iconUtils';
+import { useAllApps } from '../../hooks/useAllApps';
 import { useOS } from './store';
 
 type Props = {
@@ -15,12 +16,13 @@ export function matches(app: AppManifest, q: string) {
 }
 
 export function Launcher({ open, onClose }: Props) {
+  const apps = useAllApps();
   const openApp = useOS((s) => s.openApp);
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const filtered = useMemo(() => apps.filter((a) => matches(a, query)), [query]);
+  const filtered = useMemo(() => apps.filter((a) => matches(a, query)), [apps, query]);
 
   useEffect(() => {
     if (open) {

--- a/src/components/os/WindowManager.tsx
+++ b/src/components/os/WindowManager.tsx
@@ -1,7 +1,7 @@
 import { Suspense, lazy, useMemo } from 'react';
 import { Window } from './Window';
 import { useOS } from './store';
-import { apps } from '../../apps/registry';
+import { useAllApps } from '../../hooks/useAllApps';
 
 type Props = {
   viewport: { w: number; h: number };
@@ -9,7 +9,10 @@ type Props = {
 
 const nativeCache = new Map<string, ReturnType<typeof lazy>>();
 
-function getNativeComponent(appId: string, loader?: () => Promise<{ default: React.ComponentType }>) {
+function getNativeComponent(
+  appId: string,
+  loader?: () => Promise<{ default: React.ComponentType<Record<string, unknown>> }>
+) {
   if (!loader) return null;
   const cached = nativeCache.get(appId);
   if (cached) return cached;
@@ -20,7 +23,8 @@ function getNativeComponent(appId: string, loader?: () => Promise<{ default: Rea
 
 export function WindowManager({ viewport }: Props) {
   const windows = useOS((s) => s.windows);
-  const appMap = useMemo(() => new Map(apps.map((a) => [a.id, a])), []);
+  const allApps = useAllApps();
+  const appMap = useMemo(() => new Map(allApps.map((a) => [a.id, a])), [allApps]);
 
   return (
     <>
@@ -43,7 +47,7 @@ export function WindowManager({ viewport }: Props) {
           const LazyC = getNativeComponent(app.id, app.component);
           body = LazyC ? (
             <Suspense fallback={<NativePending name={app.name} />}>
-              <LazyC />
+              <LazyC {...(app.componentProps ?? {})} />
             </Suspense>
           ) : (
             <NativePlaceholder name={app.name} />

--- a/src/components/os/apps/RepoInfoApp.tsx
+++ b/src/components/os/apps/RepoInfoApp.tsx
@@ -1,0 +1,100 @@
+import type { FeaturedRepo } from '../../../apps/featuredRepos';
+import { relativeTime } from '../../../hooks/useProjects';
+
+type Props = {
+  repo?: FeaturedRepo;
+};
+
+export default function RepoInfoApp({ repo }: Props) {
+  if (!repo) {
+    return (
+      <div className="flex h-full items-center justify-center bg-[var(--color-void)] font-mono text-xs text-[var(--color-muted)]">
+        repo metadata missing
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-[var(--color-void)] px-6 py-5 text-[var(--color-text)]">
+      <header className="flex items-start gap-4">
+        <span
+          aria-hidden="true"
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[14px] border border-[var(--color-border)] bg-[var(--color-panel)] text-3xl"
+        >
+          {repo.icon ?? '📦'}
+        </span>
+        <div className="min-w-0">
+          <div className="font-mono text-[11px] uppercase tracking-[0.25em] text-[var(--color-amber)]">
+            {repo.private ? 'Private repo' : repo.fork ? 'Forked repo' : 'Repo'}
+          </div>
+          <h2 className="mt-1 truncate font-[var(--font-display)] text-xl font-semibold">
+            {repo.fullName}
+          </h2>
+          {repo.description && (
+            <p className="mt-1.5 text-sm leading-relaxed text-[var(--color-dim)]">
+              {repo.description}
+            </p>
+          )}
+        </div>
+      </header>
+
+      <dl className="mt-5 grid grid-cols-2 gap-3 font-mono text-[11px] sm:grid-cols-4">
+        <Stat label="Language" value={repo.language ?? '—'} />
+        <Stat label="Stars" value={`★ ${repo.stargazersCount}`} />
+        <Stat label="Updated" value={repo.updatedAt ? relativeTime(repo.updatedAt) : '—'} />
+        <Stat
+          label="Visibility"
+          value={repo.private ? 'private' : repo.fork ? 'fork' : 'public'}
+        />
+      </dl>
+
+      <section className="mt-6 grid gap-2 sm:grid-cols-2">
+        <LinkCard label="Open on GitHub" href={repo.htmlUrl} />
+        {repo.homepage && <LinkCard label="Open live site" href={repo.homepage} accent />}
+      </section>
+
+      {repo.private && (
+        <p className="mt-4 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 px-3 py-2 text-[11px] text-[var(--color-muted)]">
+          This repo is private — link opens the GitHub page but code is only visible to
+          authorized users.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 px-3 py-2">
+      <dt className="text-[10px] uppercase tracking-wider text-[var(--color-muted)]">{label}</dt>
+      <dd className="mt-0.5 text-[var(--color-text)]">{value}</dd>
+    </div>
+  );
+}
+
+function LinkCard({
+  label,
+  href,
+  accent = false,
+}: {
+  label: string;
+  href: string;
+  accent?: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener"
+      className={[
+        'group flex items-center justify-between rounded-md border px-3 py-2.5 font-mono text-xs transition',
+        accent
+          ? 'border-[var(--color-amber)]/60 bg-[var(--color-amber)]/10 text-[var(--color-amber)] hover:bg-[var(--color-amber)]/20'
+          : 'border-[var(--color-border)] bg-[var(--color-panel)]/60 text-[var(--color-text)] hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]',
+      ].join(' ')}
+    >
+      <span>{label}</span>
+      <span aria-hidden="true">↗</span>
+    </a>
+  );
+}

--- a/src/hooks/useAllApps.ts
+++ b/src/hooks/useAllApps.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { apps, type AppManifest } from '../apps/registry';
+import { useFeaturedApps } from './useFeaturedApps';
+
+export function useAllApps(): AppManifest[] {
+  const featured = useFeaturedApps();
+  return useMemo(() => {
+    if (featured.length === 0) return apps;
+    const staticIds = new Set(apps.map((a) => a.id));
+    const merged = [...apps];
+    for (const f of featured) {
+      if (!staticIds.has(f.id)) merged.push(f);
+    }
+    return merged;
+  }, [featured]);
+}

--- a/src/hooks/useFeaturedApps.test.ts
+++ b/src/hooks/useFeaturedApps.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { FeaturedRepo } from '../apps/featuredRepos';
+import { featuredRepoToApp } from './useFeaturedApps';
+
+const base: FeaturedRepo = {
+  fullName: 'schmug/scubascore',
+  name: 'scubascore',
+  icon: '🤿',
+  description: 'Dive log scoring',
+  htmlUrl: 'https://github.com/schmug/scubascore',
+  homepage: null,
+  language: 'Python',
+  stargazersCount: 1,
+  updatedAt: '2026-04-01T00:00:00Z',
+  fork: false,
+  archived: false,
+  private: false,
+};
+
+describe('featuredRepoToApp', () => {
+  it('maps a repo without homepage to a native RepoInfoApp', () => {
+    const app = featuredRepoToApp(base);
+    expect(app.type).toBe('native');
+    expect(app.url).toBeUndefined();
+    expect(typeof app.component).toBe('function');
+    expect(app.componentProps).toEqual({ repo: base });
+  });
+
+  it('maps a repo with a homepage to an iframe app pointing at that homepage', () => {
+    const app = featuredRepoToApp({ ...base, homepage: 'https://feedsearch.dev' });
+    expect(app.type).toBe('iframe');
+    expect(app.url).toBe('https://feedsearch.dev');
+    expect(app.component).toBeUndefined();
+  });
+
+  it('uses the repo short name as the app name', () => {
+    const app = featuredRepoToApp({ ...base, name: 'FeedBat' });
+    expect(app.name).toBe('FeedBat');
+  });
+
+  it('derives a stable, gh-prefixed id from the fullName', () => {
+    expect(featuredRepoToApp(base).id).toBe('gh:schmug/scubascore');
+  });
+
+  it('defaults the icon to a package emoji when the config omits one', () => {
+    const { icon, ...rest } = base;
+    void icon;
+    const app = featuredRepoToApp(rest as FeaturedRepo);
+    expect(app.icon).toBe('📦');
+  });
+
+  it('tags every featured app as a singleton (allowMultiple: false)', () => {
+    expect(featuredRepoToApp(base).allowMultiple).toBe(false);
+  });
+
+  it('carries through the githubRepo field so context menus can link to GitHub', () => {
+    expect(featuredRepoToApp(base).githubRepo).toBe('schmug/scubascore');
+  });
+});

--- a/src/hooks/useFeaturedApps.ts
+++ b/src/hooks/useFeaturedApps.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { appIdForFeaturedRepo, type FeaturedRepo } from '../apps/featuredRepos';
+import type { AppManifest } from '../apps/registry';
+import { useProjects } from './useProjects';
+
+const DEFAULT_SIZE = { w: 640, h: 540 };
+const MIN_SIZE = { w: 360, h: 320 };
+
+export function featuredRepoToApp(repo: FeaturedRepo): AppManifest {
+  const base = {
+    id: appIdForFeaturedRepo(repo.fullName),
+    name: repo.name,
+    description: repo.description ?? `${repo.fullName} on GitHub`,
+    icon: repo.icon ?? '📦',
+    defaultSize: DEFAULT_SIZE,
+    minSize: MIN_SIZE,
+    allowMultiple: false,
+    githubRepo: repo.fullName,
+  } as const;
+
+  if (repo.homepage) {
+    return {
+      ...base,
+      type: 'iframe',
+      url: repo.homepage,
+    };
+  }
+
+  return {
+    ...base,
+    type: 'native',
+    component: () => import('../components/os/apps/RepoInfoApp'),
+    componentProps: { repo },
+  };
+}
+
+export function useFeaturedApps(): AppManifest[] {
+  const { payload } = useProjects();
+  return useMemo(() => {
+    const featured = payload?.featured;
+    if (!featured || featured.length === 0) return [];
+    return featured.map(featuredRepoToApp);
+  }, [payload?.featured]);
+}

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import type { FeaturedRepo } from '../apps/featuredRepos';
 import type { Repo } from '../lib/github';
 
 export type ProjectsPayload = {
@@ -6,6 +7,7 @@ export type ProjectsPayload = {
     Repo,
     'name' | 'description' | 'html_url' | 'homepage' | 'language' | 'stargazers_count' | 'updated_at'
   >[];
+  featured?: FeaturedRepo[];
   fetchedAt: string;
 };
 

--- a/src/lib/github.buildFeatured.test.ts
+++ b/src/lib/github.buildFeatured.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import type { FeaturedRepoConfig } from '../apps/featuredRepos';
+import { buildFeaturedRepos, type Repo } from './github';
+
+const repo = (overrides: Partial<Repo> = {}): Repo => ({
+  name: 'scubascore',
+  description: 'Dive log scoring',
+  html_url: 'https://github.com/schmug/scubascore',
+  homepage: null,
+  language: 'Python',
+  stargazers_count: 1,
+  updated_at: '2026-04-01T00:00:00Z',
+  fork: false,
+  archived: false,
+  topics: [],
+  ...overrides,
+});
+
+describe('buildFeaturedRepos', () => {
+  it('enriches a public, non-fork repo from the API response', () => {
+    const configs: FeaturedRepoConfig[] = [{ fullName: 'schmug/scubascore', icon: '🤿' }];
+    const out = buildFeaturedRepos([repo()], configs);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      fullName: 'schmug/scubascore',
+      name: 'scubascore',
+      icon: '🤿',
+      language: 'Python',
+      private: false,
+      fork: false,
+    });
+  });
+
+  it('includes forks when they are named in the config', () => {
+    const configs: FeaturedRepoConfig[] = [{ fullName: 'schmug/cupid' }];
+    const out = buildFeaturedRepos(
+      [repo({ name: 'cupid', fork: true, language: 'Pascal' })],
+      configs
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ fullName: 'schmug/cupid', fork: true, language: 'Pascal' });
+  });
+
+  it('matches config fullName against repo.name case-insensitively', () => {
+    const configs: FeaturedRepoConfig[] = [{ fullName: 'schmug/FeedBat' }];
+    const out = buildFeaturedRepos([repo({ name: 'FeedBat', language: 'JavaScript' })], configs);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('FeedBat');
+  });
+
+  it('falls back to manual metadata for repos missing from the API (private)', () => {
+    const configs: FeaturedRepoConfig[] = [
+      {
+        fullName: 'schmug/school-calendar',
+        icon: '📅',
+        manual: {
+          description: 'Private tool',
+          language: 'TypeScript',
+          htmlUrl: 'https://github.com/schmug/school-calendar',
+        },
+      },
+    ];
+    const out = buildFeaturedRepos([], configs);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      fullName: 'schmug/school-calendar',
+      private: true,
+      language: 'TypeScript',
+      description: 'Private tool',
+    });
+    expect(out[0].updatedAt).toBeNull();
+  });
+
+  it('drops entries that are neither in the API response nor have a manual override', () => {
+    const configs: FeaturedRepoConfig[] = [{ fullName: 'schmug/ghost' }];
+    expect(buildFeaturedRepos([], configs)).toEqual([]);
+  });
+
+  it('normalises an empty-string homepage to null', () => {
+    const configs: FeaturedRepoConfig[] = [{ fullName: 'schmug/qr-me' }];
+    const out = buildFeaturedRepos([repo({ name: 'qr-me', homepage: '' })], configs);
+    expect(out[0].homepage).toBeNull();
+  });
+
+  it('preserves order from the config, not the API response', () => {
+    const configs: FeaturedRepoConfig[] = [
+      { fullName: 'schmug/b' },
+      { fullName: 'schmug/a' },
+    ];
+    const out = buildFeaturedRepos([repo({ name: 'a' }), repo({ name: 'b' })], configs);
+    expect(out.map((r) => r.name)).toEqual(['b', 'a']);
+  });
+});

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,3 +1,10 @@
+import {
+  featuredRepos,
+  repoNameFromFullName,
+  type FeaturedRepo,
+  type FeaturedRepoConfig,
+} from '../apps/featuredRepos';
+
 export type Repo = {
   name: string;
   description: string | null;
@@ -11,7 +18,7 @@ export type Repo = {
   topics?: string[];
 };
 
-export async function fetchOriginalRepos(username: string): Promise<Repo[]> {
+export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const url = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
   try {
     const res = await fetch(url, {
@@ -24,10 +31,64 @@ export async function fetchOriginalRepos(username: string): Promise<Repo[]> {
       console.warn(`GitHub API returned ${res.status} for ${username}; returning empty repo list.`);
       return [];
     }
-    const data = (await res.json()) as Repo[];
-    return data.filter((r) => !r.fork && !r.archived);
+    return (await res.json()) as Repo[];
   } catch (err) {
     console.warn(`GitHub API fetch failed for ${username}; returning empty repo list.`, err);
     return [];
   }
+}
+
+export async function fetchOriginalRepos(username: string): Promise<Repo[]> {
+  const all = await fetchAllRepos(username);
+  return all.filter((r) => !r.fork && !r.archived);
+}
+
+export function buildFeaturedRepos(
+  repos: Repo[],
+  configs: FeaturedRepoConfig[] = featuredRepos
+): FeaturedRepo[] {
+  const byName = new Map(repos.map((r) => [r.name.toLowerCase(), r]));
+  const out: FeaturedRepo[] = [];
+
+  for (const cfg of configs) {
+    const shortName = repoNameFromFullName(cfg.fullName);
+    const repo = byName.get(shortName.toLowerCase());
+
+    if (repo) {
+      out.push({
+        fullName: cfg.fullName,
+        name: repo.name,
+        icon: cfg.icon,
+        description: repo.description,
+        htmlUrl: repo.html_url,
+        homepage: repo.homepage && repo.homepage.trim() ? repo.homepage : null,
+        language: repo.language,
+        stargazersCount: repo.stargazers_count,
+        updatedAt: repo.updated_at,
+        fork: repo.fork,
+        archived: repo.archived,
+        private: false,
+      });
+      continue;
+    }
+
+    if (cfg.manual) {
+      out.push({
+        fullName: cfg.fullName,
+        name: shortName,
+        icon: cfg.icon,
+        description: cfg.manual.description,
+        htmlUrl: cfg.manual.htmlUrl,
+        homepage: cfg.manual.homepage ?? null,
+        language: cfg.manual.language ?? null,
+        stargazersCount: 0,
+        updatedAt: null,
+        fork: false,
+        archived: false,
+        private: true,
+      });
+    }
+  }
+
+  return out;
 }

--- a/src/pages/api/projects.json.ts
+++ b/src/pages/api/projects.json.ts
@@ -1,9 +1,10 @@
 import type { APIRoute } from 'astro';
-import { fetchOriginalRepos } from '../../lib/github';
+import { buildFeaturedRepos, fetchAllRepos } from '../../lib/github';
 
 export const GET: APIRoute = async () => {
-  const full = await fetchOriginalRepos('schmug');
-  const repos = full.map((r) => ({
+  const all = await fetchAllRepos('schmug');
+  const originals = all.filter((r) => !r.fork && !r.archived);
+  const repos = originals.map((r) => ({
     name: r.name,
     description: r.description,
     html_url: r.html_url,
@@ -13,12 +14,16 @@ export const GET: APIRoute = async () => {
     updated_at: r.updated_at,
     topics: r.topics,
   }));
-  return new Response(JSON.stringify({ repos, fetchedAt: new Date().toISOString() }), {
-    headers: {
-      'content-type': 'application/json; charset=utf-8',
-      'cache-control': 'public, max-age=3600',
-    },
-  });
+  const featured = buildFeaturedRepos(all);
+  return new Response(
+    JSON.stringify({ repos, featured, fetchedAt: new Date().toISOString() }),
+    {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'public, max-age=3600',
+      },
+    }
+  );
 };
 
 export const prerender = true;


### PR DESCRIPTION
## Summary

- Adds a data-driven `featuredRepos` config that promotes handpicked repos to first-class desktop icons alongside the existing static registry.
- Extends `/api/projects.json` with a `featured` array: public repos are enriched live from the GitHub API (forks included), private repos fall back to manual metadata.
- Adds a `RepoInfoApp` native window (name, description, language, stars, open-on-GitHub, open-live-site) and uses it for repos without a hosted iframe URL. Repos with a `homepage` automatically become iframe apps (same pattern as `dmarc.mx` etc).
- New hooks `useFeaturedApps` / `useAllApps` merge dynamic apps into the OS + mobile shells.

Featured in this cut: `scubascore`, `FeedBat`, `opml-backup`, `cupid` (fork), `untitledgoogetool` (fork), `school-calendar` (private).

Adding another repo is now a one-line edit to `src/apps/featuredRepos.ts` — no component or registry edits needed.

## Test plan

- [x] `npm test` — 85 unit tests pass, incl. new coverage for config, `featuredRepoToApp`, and `buildFeaturedRepos` (fork inclusion, private fallback, ordering, empty-homepage handling, id-collision check).
- [x] `npm run typecheck` — 0 errors.
- [x] `npm run build` — static build succeeds; `dist/api/projects.json` materialises the `featured` array (verified the private `school-calendar` entry survives a GitHub API failure).
- [ ] `npm run dev` (manual) — confirm 6 new icons on desktop + ⌘K launcher; native repos open `RepoInfoApp`, FeedBat opens its homepage as an iframe.
- [ ] `npm run test:e2e` — confirm no iframe CSP/XFO regressions (FeedBat's `feedsearch.dev` may need a headers check).
