### PR TITLE
feat: add /blog mobile workflow, CLAUDE.md, and fix mobile e2e

### DIFF
--- a/.claude/commands/blog.md
+++ b/.claude/commands/blog.md
@@ -1,0 +1,125 @@
+---
+description: Turn a voice/text dump into a polished blog post PR for cortech.online
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
+---
+
+# /blog — mobile-first blog posting
+
+Take whatever the user just dumped (typed or voice transcript) and ship it as a reviewable PR against `main`. Optimize for one Claude Code turn from a phone.
+
+## Input
+
+The user's message after `/blog` is the raw post body. If they invoked `/blog` with no body, ask **once** for the dump, then proceed without further questions — they're on a phone.
+
+## Step 1 — Light-touch edit
+
+Preserve the user's voice and phrasing. Do **not** rewrite for "flow."
+
+- Fix grammar, spelling, punctuation
+- Add `##` section headings where the dump has natural breaks (~2-4 sections for a typical post)
+- Tighten transitions between sections — don't restructure them
+- Keep their sentence shapes, slang, and asides intact
+- Strip transcription artifacts: filler words ("um", "like", "you know"), false starts, repeated words
+
+## Step 2 — Auto-enrich
+
+Identify verifiable claims and add **1–2 supporting links per major claim**:
+
+- Specific stats (e.g. "Cloudflare workers handle X requests/sec")
+- Named products, companies, papers, events
+- Quoted statements
+- Technical claims that benefit from a doc/spec link
+
+Use WebSearch to find authoritative sources, then WebFetch to confirm the link resolves and the claim is accurate. Add as inline markdown links where the claim appears. Anything that doesn't fit inline goes in a `## Further reading` section at the end.
+
+If a claim can't be verified or the user is clearly speaking subjectively ("I think", "in my experience"), leave it alone.
+
+## Step 3 — Infer metadata
+
+Generate frontmatter matching the schema in [src/content.config.ts](src/content.config.ts):
+
+- `title` — short, declarative, derived from the strongest idea. No clickbait.
+- `description` — 1–2 sentences, under ~160 chars. Used by RSS and `/blog` index.
+- `pubDate` — today's date in `YYYY-MM-DD` format. Get from `date +%Y-%m-%d`.
+- `tags` — 3–5 lowercase, kebab-case if multi-word
+- `draft: false`
+- Skip `updatedDate`
+
+## Step 4 — Slug + filename
+
+- Slug: kebab-case from title, ascii only, max ~6 words
+- Filename: `src/content/blog/<YYYY-MM-DD>-<slug>.md`
+- Files starting with `_` are ignored by Astro — never use that prefix
+
+## Step 5 — Write the post
+
+Match the format of existing posts (see [src/content/blog/2026-04-16-hello-world.md](src/content/blog/2026-04-16-hello-world.md)):
+
+```markdown
+---
+title: "Inferred title"
+description: "Inferred 1–2 sentence summary."
+pubDate: 2026-04-16
+tags: [tag-one, tag-two, tag-three]
+draft: false
+---
+
+## First section heading
+
+Body of the post with [inline links](https://example.com) where they support claims.
+
+## Second section
+
+More body.
+
+## Further reading
+
+- [Source one](https://example.com/one) — what it is
+- [Source two](https://example.com/two) — what it is
+```
+
+## Step 6 — Branch, commit, PR
+
+Run these in order. Use the slug from Step 4.
+
+```bash
+git checkout -b claude/blog-<slug>
+git add src/content/blog/<YYYY-MM-DD>-<slug>.md
+git commit -m "$(cat <<'EOF'
+feat(blog): <title>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin claude/blog-<slug>
+gh pr create --title "feat(blog): <title>" --body "$(cat <<'EOF'
+## Summary
+
+<the post's `description` field>
+
+**Tags:** `<tag-one>`, `<tag-two>`, `<tag-three>`
+
+## Review checklist
+
+- [ ] Cloudflare Pages preview renders the post correctly
+- [ ] Title, description, and tags read well
+- [ ] Inline research links resolve and support the claim they're attached to
+- [ ] Tone matches voice
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Step 7 — Report
+
+Output the PR URL on its own line so it's tappable on mobile. One sentence summary above it. Done.
+
+## Out of scope
+
+Defer these to follow-up commands or manual edits:
+
+- Image uploads (no good mobile flow yet)
+- `draft: true` posts
+- `updatedDate` revisions to existing posts
+- Re-running on PR feedback (just edit the PR or run `/blog` again with refined input)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo. Keep concise — link out, don't duplicate.
+
+## What this is
+
+The portfolio at [cortech.online](https://cortech.online) — a single Astro static page that hydrates one React island. The island chooses between `OSShell` (desktop, ≥768px) and `MobileShell` (<768px). Built with Astro 6, React 19, Tailwind v4, zustand. Hosted on Cloudflare Pages, auto-deployed on merge to `main`.
+
+## Test & verify
+
+Run before claiming work is complete:
+
+```sh
+npm run typecheck    # astro check && tsc --noEmit
+npm test             # vitest, ~63 unit tests, sub-second
+npm run test:e2e     # playwright, auto-starts dev server on :4321
+```
+
+`npm run build` catches blog-post schema errors that the typecheck misses — run it after touching anything in `src/content/blog/` or `src/content.config.ts`.
+
+There is **no CI workflow** today. Treat green local tests as the merge gate.
+
+## Deploy
+
+Cloudflare Pages, settings in [README.md](README.md#build--deploy). `public/_routes.json` excludes everything from the Functions runtime — pure static asset serving. Pushing to `main` triggers a deploy; PRs get a preview URL automatically.
+
+## Blog posts
+
+Markdown in `src/content/blog/`, schema in [src/content.config.ts](src/content.config.ts), template at [src/content/blog/_template.md](src/content/blog/_template.md). Files starting with `_` are ignored. Frontmatter: `title`, `description`, `pubDate`, `tags`, `draft`. Posts feed `/blog`, `/rss.xml`, and the desktop Blog app simultaneously.
+
+For mobile drafting, use the **`/blog` slash command** ([.claude/commands/blog.md](.claude/commands/blog.md)) — it turns a voice/text dump into a reviewable PR in one turn.
+
+## Window-OS conventions
+
+The app registry, window-manager store shape, a11y contract, and deploy contract live in [docs/architecture.md](docs/architecture.md). Read it before adding an app or changing window behavior. Original design rationale: [docs/superpowers/specs/2026-04-12-cortechos-design.md](docs/superpowers/specs/2026-04-12-cortechos-design.md).
+
+To add an app: append one entry to [src/apps/registry.ts](src/apps/registry.ts) — the launcher, desktop icons, and taskbar pick it up automatically. **Update the mobile springboard tile-count assertion** in [e2e/smoke.spec.ts](e2e/smoke.spec.ts) when you do (it currently expects 8).
+
+Iframe apps must allow framing (no `X-Frame-Options: DENY`, no restrictive `frame-ancestors`) — the iframe-embed Playwright suite enforces this.
+
+## Code style
+
+- No `index.ts` barrels — import from concrete files
+- Tests colocate as `.test.ts(x)` next to source
+- Zustand store mutations stay inside store actions, never inline in components
+- Window-relative units come from the store, not CSS — see `src/components/os/store.ts`
+- Comments only when the *why* is non-obvious. Don't restate what the code does.
+- Site owner is referred to as **Schmug**, not Cory ([commit 1a5d204](https://github.com/schmug/portfolio/commit/1a5d204))

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -213,9 +213,9 @@ test.describe('mobile springboard', () => {
     await expect(grid).toBeVisible({ timeout: 15_000 });
     await expect(page.locator('#ct-desktop')).toHaveCount(0);
 
-    // All 7 registry apps rendered as tiles.
+    // All 8 registry apps rendered as tiles.
     const tiles = grid.locator('button[aria-label^="Open "]');
-    expect(await tiles.count()).toBe(7);
+    expect(await tiles.count()).toBe(8);
 
     // Dock shows 3 pinned apps (About, Support, Projects).
     const dockButtons = page.locator('nav[aria-label="Dock"] button');


### PR DESCRIPTION
## Summary

- Add **/blog slash command** ([.claude/commands/blog.md](.claude/commands/blog.md)) that turns a phone-side voice or text dump into a reviewable PR in one Claude Code turn. Light-touch edits (preserve voice, fix grammar, add headings), auto-enriches verifiable claims with research links, infers all frontmatter, opens `claude/blog-<slug>` branch + PR.
- Add **root CLAUDE.md** consolidating test commands, deploy flow, blog system pointers, and key conventions. Points at [docs/architecture.md](docs/architecture.md) for the deeper window-OS contract instead of duplicating.
- Fix **mobile springboard e2e**: tile-count assertion was hardcoded to 7 but the blog app addition in #22 brought the registry to 8. Added a CLAUDE.md note to update this assertion when adding apps.

## Why

Schmug wants to draft blog posts from the Claude Code mobile app — voice or text — and have them land as PRs he can review/merge from his phone. The blog plumbing already existed (Astro content collections, RSS merge, desktop card from #22); what was missing was a one-shot entry point. The new slash command is that entry point.

CLAUDE.md was overdue — conventions were scattered across README and docs/architecture.md, and now that there's a slash command future Claude sessions need to know about, having a single root file to bootstrap from is worth it.

The e2e fix is a drive-by — caught it while running the full test suite to verify the new files didn't regress anything.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 63/63 unit tests pass
- [x] `npm run test:e2e` — 8/8 (was 7/8 on main due to the stale tile count)
- [x] `npm run build` — clean, all pages generated including the existing hello-world post
- [ ] Smoke test `/blog` from mobile after merge — dictate ~2 paragraphs and confirm a PR lands with a working Cloudflare Pages preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)