### PR TITLE
Replay boot splash on every new browser session

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -183,7 +183,7 @@ test.describe('desktop interactions', () => {
     expect(projBefore).toBeTruthy();
 
     await page.reload();
-    // hasBooted is persisted → no splash on reload.
+    // sessionStorage survives reload → no splash on reload within a visit.
     await expect(page.locator('#ct-desktop')).toBeVisible({ timeout: 15_000 });
     await expect(win).toBeVisible();
 

--- a/src/components/os/BootSplash.tsx
+++ b/src/components/os/BootSplash.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useOS } from './store';
 
 type Phase = 'playing' | 'fading' | 'hidden';
@@ -10,11 +10,33 @@ const STATUS_LINES = [
   'cortechos: ready.',
 ];
 
+const SESSION_KEY = 'cortechos:booted';
+
+function alreadyBootedThisSession(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(SESSION_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
 export function BootSplash() {
-  const hasBooted = useOS((s) => s.hasBooted);
   const setBooted = useOS((s) => s.setBooted);
-  const [phase, setPhase] = useState<Phase>(hasBooted ? 'hidden' : 'playing');
+  const [phase, setPhase] = useState<Phase>(() =>
+    alreadyBootedThisSession() ? 'hidden' : 'playing'
+  );
   const [statusIndex, setStatusIndex] = useState(0);
+
+  const markBooted = useCallback(() => {
+    setPhase('hidden');
+    setBooted(true);
+    try {
+      window.sessionStorage.setItem(SESSION_KEY, '1');
+    } catch {
+      // sessionStorage can throw in private modes — splash still hides.
+    }
+  }, [setBooted]);
 
   useEffect(() => {
     if (phase === 'hidden') return;
@@ -30,34 +52,27 @@ export function BootSplash() {
       );
     });
     const t1 = setTimeout(() => setPhase('fading'), total);
-    const t2 = setTimeout(() => {
-      setPhase('hidden');
-      setBooted(true);
-    }, total + fadeOut);
+    const t2 = setTimeout(markBooted, total + fadeOut);
 
     return () => {
       lineTimers.forEach(clearTimeout);
       clearTimeout(t1);
       clearTimeout(t2);
     };
-  }, [phase, setBooted]);
+  }, [phase, markBooted]);
 
   useEffect(() => {
     if (phase === 'hidden') return;
-    const skip = () => {
-      setPhase('hidden');
-      setBooted(true);
-    };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key) skip();
+      if (e.key) markBooted();
     };
     document.addEventListener('keydown', onKey);
-    document.addEventListener('mousedown', skip);
+    document.addEventListener('mousedown', markBooted);
     return () => {
       document.removeEventListener('keydown', onKey);
-      document.removeEventListener('mousedown', skip);
+      document.removeEventListener('mousedown', markBooted);
     };
-  }, [phase, setBooted]);
+  }, [phase, markBooted]);
 
   if (phase === 'hidden') return null;
 

--- a/src/components/os/store.test.ts
+++ b/src/components/os/store.test.ts
@@ -21,6 +21,7 @@ function makeApp(overrides: Partial<AppManifest> = {}): AppManifest {
 beforeEach(() => {
   useOS.setState({ windows: [], focusedId: null, nextZ: 1, hasBooted: false });
   localStorage.clear();
+  sessionStorage.clear();
 });
 
 describe('openApp', () => {
@@ -188,15 +189,16 @@ describe('moveWindow / resizeWindow', () => {
 });
 
 describe('persistence partialize', () => {
-  it('persists windows/nextZ/hasBooted but not focusedId', () => {
+  it('persists windows/nextZ but not focusedId/hasBooted', () => {
     const opts = useOS.persist.getOptions();
     expect(opts.partialize).toBeDefined();
     const slice = opts.partialize!(useOS.getState()) as Record<string, unknown>;
-    expect(Object.keys(slice).sort()).toEqual(['hasBooted', 'nextZ', 'windows']);
+    expect(Object.keys(slice).sort()).toEqual(['nextZ', 'windows']);
     expect(slice).not.toHaveProperty('focusedId');
+    expect(slice).not.toHaveProperty('hasBooted');
   });
 
-  it('openApp writes a partialized slice (no focusedId) to localStorage', () => {
+  it('openApp writes a partialized slice (no focusedId/hasBooted) to localStorage', () => {
     useOS.getState().openApp(makeApp({ id: 'a' }));
     useOS.setState({ hasBooted: true });
 
@@ -204,13 +206,14 @@ describe('persistence partialize', () => {
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
     expect(parsed.state).not.toHaveProperty('focusedId');
+    expect(parsed.state).not.toHaveProperty('hasBooted');
     expect(parsed.state.windows).toHaveLength(1);
-    expect(parsed.state.hasBooted).toBe(true);
   });
 
   it('rehydrate loads a preset localStorage blob and leaves focusedId null', async () => {
     // Preset a saved layout directly; bypass openApp so the in-memory write
-    // doesn't re-trigger persistence.
+    // doesn't re-trigger persistence. hasBooted is no longer persisted — it
+    // lives in sessionStorage so the splash replays per visit.
     const blob = {
       state: {
         windows: [
@@ -229,7 +232,6 @@ describe('persistence partialize', () => {
           },
         ],
         nextZ: 6,
-        hasBooted: true,
       },
       version: 1,
     };
@@ -242,7 +244,6 @@ describe('persistence partialize', () => {
     expect(after.windows[0]!.id).toBe('preset');
     expect(after.windows[0]!.x).toBe(100);
     expect(after.nextZ).toBe(6);
-    expect(after.hasBooted).toBe(true);
     expect(after.focusedId).toBeNull();
   });
 });

--- a/src/components/os/store.ts
+++ b/src/components/os/store.ts
@@ -44,13 +44,25 @@ function nextCascade(count: number): { x: number; y: number } {
   return { x: INITIAL_OFFSET + step * CASCADE, y: INITIAL_OFFSET + step * CASCADE };
 }
 
+// Boot state is per-session, not per-browser: the splash replays on every new
+// tab but stays dismissed on reload. Seeding from sessionStorage here keeps
+// OSShell's first-boot capture in sync with the splash's skip decision.
+function readBootedFromSession(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem('cortechos:booted') === '1';
+  } catch {
+    return false;
+  }
+}
+
 export const useOS = create<OSState>()(
   persist(
     (set, get) => ({
       windows: [],
       focusedId: null,
       nextZ: 1,
-      hasBooted: false,
+      hasBooted: readBootedFromSession(),
 
       openApp: (app, opts) => {
         const state = get();
@@ -175,7 +187,6 @@ export const useOS = create<OSState>()(
       partialize: (s) => ({
         windows: s.windows,
         nextZ: s.nextZ,
-        hasBooted: s.hasBooted,
       }),
     }
   )


### PR DESCRIPTION
## Summary

- Move the boot-splash gate from persisted `hasBooted` in localStorage to per-session state in `sessionStorage`, so the CortechOS intro replays on every new tab/visit instead of only on the very first ever.
- Reloads within a visit and `/` ↔ `/blog` navigation still skip the splash — sessionStorage survives reloads but not tab close.
- Nice side effect: the welcome auto-open of the About window also fires on the first load of each new session.

## Why

Returning visitors never saw the boot animation again — it's part of the site's personality, and Schmug wanted it back on every visit without spamming it on every route click. Session scope is the natural unit for "landing on the page."

## What changed

- `src/components/os/store.ts` — drop `hasBooted` from the zustand `partialize` list; seed it from `sessionStorage['cortechos:booted']` at store creation so `OSShell`'s first-boot capture stays in sync with the splash's skip decision.
- `src/components/os/BootSplash.tsx` — owns the session flag via a new `markBooted` helper that fires on both the timed fade-out and the any-key / click skip. Initial phase reads sessionStorage.
- `src/components/os/store.test.ts` — partialize tests now expect `['nextZ', 'windows']` and assert `hasBooted` is absent from the persisted blob; rehydrate preset no longer carries `hasBooted`; `sessionStorage` cleared in `beforeEach`.
- `e2e/smoke.spec.ts` — comment refresh: reload-no-splash now explained by sessionStorage, not localStorage. Behavior unchanged — the assertion still holds.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 85/85 pass (store persistence suite covers the new partialize shape)
- [ ] Local manual: fresh tab → splash plays + About auto-opens; reload → no splash; `/` → `/blog` → `/` → no splash; close tab, reopen `/` → splash plays again
- [ ] `npm run test:e2e` on CI preview (reload-no-splash assertion in `e2e/smoke.spec.ts`)
- [ ] Respect `prefers-reduced-motion` — shortened animation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)