### PR TITLE
feat(seo): publish robots.txt, sitemap, and agent-readiness metadata

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
@@ -13,5 +14,10 @@ export default defineConfig({
     plugins: [tailwindcss()]
   },
 
-  integrations: [react()]
+  integrations: [
+    react(),
+    sitemap({
+      filter: (page) => !page.includes('/api/') && !page.endsWith('/rss.xml'),
+    }),
+  ]
 });

--- a/e2e/agent-ready.spec.ts
+++ b/e2e/agent-ready.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+// Notes on what's *not* asserted here:
+//   - /sitemap-index.xml and /sitemap-0.xml are emitted by the
+//     @astrojs/sitemap integration at build time. They don't exist
+//     under `astro dev`, so the contract is verified by the
+//     `[@astrojs/sitemap] \`sitemap-index.xml\` created at \`dist\``
+//     line in `npm run build` output rather than here.
+//   - `public/_headers` (Link rels on /, Content-Type override on
+//     /.well-known/api-catalog) is applied by Cloudflare Pages at the
+//     edge, not by the Astro dev server.
+
+test.describe('agent readiness', () => {
+  test('/robots.txt is served plain-text with AI rules, Content-Signal, and sitemap', async ({ request }) => {
+    const res = await request.get('/robots.txt');
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toMatch(/text\/plain/);
+
+    const body = await res.text();
+    expect(body).toMatch(/Content-Signal:\s*ai-train=no,\s*search=yes,\s*ai-input=yes/);
+    expect(body).toContain('User-agent: GPTBot');
+    expect(body).toContain('User-agent: ClaudeBot');
+    expect(body).toMatch(/Sitemap:\s*https:\/\/cortech\.online\/sitemap-index\.xml/);
+  });
+
+  test('/.well-known/api-catalog is a valid RFC 9727 linkset', async ({ request }) => {
+    const res = await request.get('/.well-known/api-catalog');
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.linkset)).toBe(true);
+    expect(data.linkset.length).toBeGreaterThan(0);
+    const anchors = data.linkset.map((e: { anchor: string }) => e.anchor);
+    expect(anchors).toContain('https://cortech.online/api/blog.json');
+    expect(anchors).toContain('https://cortech.online/api/projects.json');
+    expect(anchors).toContain('https://cortech.online/rss.xml');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@astrojs/rss": "^4.0.18",
+        "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -220,6 +221,17 @@
       "dependencies": {
         "fast-xml-parser": "^5.5.7",
         "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
         "zod": "^4.3.6"
       }
     },
@@ -2537,7 +2549,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2561,6 +2572,15 @@
       "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -2948,6 +2968,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6495,6 +6521,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -6538,6 +6598,12 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -6809,7 +6875,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@astrojs/react": "^5.0.3",
     "@astrojs/rss": "^4.0.18",
+    "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,28 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://cortech.online/api/blog.json",
+      "describedby": [
+        { "href": "https://cortech.online/blog", "type": "text/html" }
+      ],
+      "type": [
+        { "href": "https://cortech.online/api/blog.json" }
+      ]
+    },
+    {
+      "anchor": "https://cortech.online/api/projects.json",
+      "describedby": [
+        { "href": "https://cortech.online/projects", "type": "text/html" }
+      ],
+      "type": [
+        { "href": "https://cortech.online/api/projects.json" }
+      ]
+    },
+    {
+      "anchor": "https://cortech.online/rss.xml",
+      "alternate": [
+        { "href": "https://cortech.online/rss.xml", "type": "application/rss+xml" }
+      ]
+    }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/.well-known/api-catalog
+  Content-Type: application/linkset+json
+  Cache-Control: public, max-age=3600
+
+/
+  Link: </.well-known/api-catalog>; rel="api-catalog"
+  Link: </rss.xml>; rel="alternate"; type="application/rss+xml"
+  Link: </sitemap-index.xml>; rel="sitemap"; type="application/xml"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,37 @@
+# robots.txt for cortech.online
+# RFC 9309 — https://www.rfc-editor.org/rfc/rfc9309
+# Content Signals — https://contentsignals.org/
+
+User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+
+# --- AI agents: search + real-time fetch (allowed) ---
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+# --- AI crawlers: training corpus builders (disallowed) ---
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+Sitemap: https://cortech.online/sitemap-index.xml


### PR DESCRIPTION
## Summary

Closes six of the twelve gaps flagged by [isitagentready.com](https://isitagentready.com) — everything that can be done as static assets on Cloudflare Pages without standing up Functions.

- `public/robots.txt` — RFC 9309 rules with a [contentsignals.org](https://contentsignals.org/) `Content-Signal: ai-train=no, search=yes, ai-input=yes` directive. Allows agent-search + live-fetch crawlers (OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, PerplexityBot), disallows training-corpus crawlers (GPTBot, Google-Extended, CCBot), and points at the new sitemap.
- `@astrojs/sitemap` integration — generates `/sitemap-index.xml` + `/sitemap-0.xml` at build time, filtered to exclude `/api/*` JSON feeds and `/rss.xml` (those aren't canonical pages).
- `public/.well-known/api-catalog` — RFC 9727 linkset advertising `/api/blog.json`, `/api/projects.json`, and the RSS feed.
- `public/_headers` — Cloudflare Pages config that serves the api-catalog as `application/linkset+json` and advertises `api-catalog`, `alternate` (RSS), and `sitemap` rels as `Link:` response headers on `/`.

## Intentionally out of scope

Documented in the plan file, not bundled here:

- **Markdown-for-Agents** (`Accept: text/markdown` negotiation) — needs a runtime; this site is `output: 'static'` with `_routes.json` excluding Functions.
- **OAuth/OIDC discovery**, **OAuth Protected Resource** — site has no auth.
- **MCP Server Card**, **Agent Skills index** — no MCP server or skills published from this domain; advertising them would be misleading.
- **WebMCP** — worth a dedicated brainstorm (needs meaningful tool definitions for the desktop-OS shell), not a quick fix.

## Reviewer notes

- The `Link:` response headers and the `application/linkset+json` content-type override only take effect on Cloudflare Pages at the edge — the Astro dev server and `astro preview` don't apply `_headers`. Confirm via the PR's Pages preview URL (or re-run the [isitagentready.com](https://isitagentready.com) crawl against it).
- Sitemap files are generated at build time, not served by `astro dev` — the e2e spec deliberately skips those and relies on the `[@astrojs/sitemap] sitemap-index.xml created at dist` line in `npm run build` output as the contract.
- Default `User-agent: *` still gets `Allow: /` — classical search engines (Googlebot, Bingbot) are unchanged.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 85/85 unit tests pass
- [x] `npm run test:e2e` — 10/10 Playwright tests pass (8 existing + 2 new in `e2e/agent-ready.spec.ts`)
- [x] `npm run build` — confirms `sitemap-index.xml`/`sitemap-0.xml` emitted, and the sitemap includes `/`, `/about`, `/blog`, `/blog/<slug>`, `/projects`, `/shell` but excludes `/api/*` and `/rss.xml`
- [ ] Against the Pages preview URL: `curl -sI` each new path to confirm status + content-type, and `curl -sI /` to confirm the `Link:` headers are present
- [ ] Re-run [isitagentready.com](https://isitagentready.com) against the preview URL; the six in-scope goals should flip to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)