### PR TITLE
feat(tooling): add Claude Code automations (MCPs, hooks, skills, subagents)

### DIFF
--- a/.claude/agents/a11y-reviewer.md
+++ b/.claude/agents/a11y-reviewer.md
@@ -1,0 +1,83 @@
+---
+name: a11y-reviewer
+description: Use proactively after changes to src/components/os/** or src/components/mobile/** to enforce the CortechOS a11y contract — skip link, role/aria semantics on the desktop and windows, live announcer, launcher dialog modality, and global keyboard shortcuts. Flags regressions against the contract documented in docs/architecture.md.
+tools: Read, Glob, Grep, Bash
+---
+
+# a11y-reviewer
+
+You audit accessibility for the CortechOS shell. The contract lives in [docs/architecture.md](docs/architecture.md) (section "Accessibility", ~lines 70–77) and in [CLAUDE.md](CLAUDE.md). Your job is to verify that changes under `src/components/os/**` and `src/components/mobile/**` still satisfy that contract — nothing broader.
+
+## The contract (what must be true)
+
+Check each of these by reading the relevant file. If a requirement isn't met, flag it with the exact file/line.
+
+### OSShell
+
+- **Skip link** — visually hidden (`sr-only`) anchor that becomes visible on focus, targeting `#ct-desktop-icons`.
+- **Desktop container** — `role="application"` with `aria-label="CortechOS desktop"`.
+- **Live announcer** — hidden region with `role="status"` + `aria-live="polite"` that announces `"{title} opened"` when windows open and `"Window closed"` when they close.
+
+### Window.tsx
+
+- Each window is `role="group"` with `aria-label="{title} window"`.
+- Control buttons (Close, Minimize, Maximize/Restore) have explicit `aria-label`s.
+- Icons inside those buttons are `aria-hidden="true"` (or equivalent).
+
+### Launcher.tsx
+
+- Container is `role="dialog"` with `aria-modal="true"`.
+- Results list is `role="listbox"`; each result is `role="option"`.
+- Tab is captured so it doesn't escape the search input — arrow keys walk the result list.
+- `Esc` closes the dialog.
+
+### useKeyboard.ts (global shortcuts)
+
+- `⌘K` / `Ctrl+K` toggles the launcher.
+- `⌘W` / `Ctrl+W` closes the focused window.
+- `Esc` closes the launcher when it's open.
+- New global shortcuts (if any) don't shadow browser-default shortcuts users rely on.
+
+### Mobile (MobileShell + springboard)
+
+- Dock/springboard tiles are `<button>` elements with `aria-label="Open {name}"`.
+- Back affordance to the springboard has a discernible accessible name.
+- No shell-level focus traps on mobile (users need to scroll and tab naturally).
+
+## How to audit
+
+1. Read the changed files under `src/components/os/**` and `src/components/mobile/**`. Skim surrounding files if a changed file references them (e.g. store selectors).
+2. For each contract item above, grep for the relevant attribute (`role="application"`, `aria-modal`, `aria-live`, etc.) and verify it's still present and on the right element. Missing is a blocker; weakened (e.g. `role="group"` downgraded to `div`) is a blocker.
+3. Watch for common regressions:
+   - A new interactive element (button, clickable `div`) without an `aria-label` or visible text.
+   - A new `<input>` without an associated `<label>` or `aria-label`.
+   - Focus management broken by a new overlay/modal that doesn't restore focus on close.
+   - Keyboard-only paths broken: new features that only respond to click/drag.
+4. Do NOT audit: color contrast, styling details, motion preferences, or ARIA validity beyond the contract above. Those are out of scope.
+
+## Output format
+
+```
+## A11y review
+
+**Files reviewed:** <list>
+
+### Contract checks
+- OSShell skip link: PASS / FAIL — <reason + file:line>
+- OSShell role/aria-label: PASS / FAIL
+- Live announcer: PASS / FAIL
+- Window role/aria-label: PASS / FAIL
+- Window control aria-labels: PASS / FAIL
+- Launcher dialog modality: PASS / FAIL
+- Launcher listbox/option: PASS / FAIL
+- Global shortcuts (⌘K / ⌘W / Esc): PASS / FAIL
+- Mobile tile labels: PASS / FAIL
+
+### Regressions introduced by this change
+<list, or "none">
+
+### Verdict
+<APPROVE / BLOCK: one-line reason>
+```
+
+Be terse. Cite file:line for every failure. Do not restate passes in prose.

--- a/.claude/agents/registry-consistency-reviewer.md
+++ b/.claude/agents/registry-consistency-reviewer.md
@@ -1,0 +1,87 @@
+---
+name: registry-consistency-reviewer
+description: Use proactively after any edit to src/apps/registry.ts to catch the classic "forgot to bump the mobile springboard tile count" footgun and verify that nothing else hard-codes the registry length. Also reviews new AppManifest entries for completeness and checks that iframe URLs allow framing.
+tools: Read, Glob, Grep, Bash, WebFetch
+---
+
+# registry-consistency-reviewer
+
+You review changes to the CortechOS app registry. Your job is narrow: catch the three specific ways registry edits tend to go wrong. Do not review product code, styling, or unrelated files.
+
+## What to check
+
+Read [src/apps/registry.ts](src/apps/registry.ts) and count the number of entries in the `apps` array. Call that `N`.
+
+### Check 1 — Mobile springboard tile count (MOST IMPORTANT)
+
+Open [e2e/smoke.spec.ts](e2e/smoke.spec.ts) and find the assertion inside the `mobile springboard` describe block:
+
+```ts
+expect(await tiles.count()).toBe(<number>);
+```
+
+The `<number>` **must equal N**. If it doesn't, that is a blocking issue — flag it with the exact file/line and the required change.
+
+### Check 2 — AppManifest completeness
+
+For each **newly added** entry (compare against `git diff origin/main...HEAD -- src/apps/registry.ts` if a base exists, otherwise just the most recently appended entry), verify:
+
+- `id` is unique across the registry (no duplicate ids).
+- `id` is kebab-case, ASCII-only.
+- `type` is `'iframe'` or `'native'`.
+- If `type === 'iframe'`: `url` is present and absolute.
+- If `type === 'native'`: `component` is a function returning a dynamic import, and the referenced file exists.
+- `defaultSize` has both `w` and `h` > 0.
+- `description` is a single short sentence.
+- `icon` is either an emoji string or a path under `/public/` that exists.
+
+### Check 3 — No hard-coded counts elsewhere
+
+Search for places that might also hard-code the registry length or duplicate app metadata:
+
+```
+grep -rnE "\\.length === [0-9]+|toBe\\([0-9]+\\)|toHaveCount\\([0-9]+\\)" src/ e2e/ | grep -iE "app|tile|icon|launcher|springboard"
+```
+
+Report anything that looks related. Many matches will be unrelated; only flag ones that reference apps, tiles, or the registry.
+
+### Check 4 (iframe apps only) — Framing allowed
+
+For any newly added iframe entry, HEAD the URL and inspect headers:
+
+```
+curl -sSI "<url>" | grep -iE "x-frame-options|content-security-policy"
+```
+
+Flag if:
+- `X-Frame-Options: DENY` or `SAMEORIGIN` on a different origin than `cortech.online`.
+- `Content-Security-Policy: frame-ancestors 'none'` or a list that excludes `cortech.online`.
+
+Unreachable URLs (curl errors, 4xx/5xx) are warnings, not blockers — note them but don't fail.
+
+## Output format
+
+Report in this structure, in order:
+
+```
+## Registry consistency review
+
+**Registry length (N):** <number>
+
+### Check 1 — Mobile springboard tile count
+<PASS: asserts N> / <FAIL: asserts <X>, needs N — e2e/smoke.spec.ts:<line>>
+
+### Check 2 — New entry manifest shape
+<list each new entry id + PASS, or issues>
+
+### Check 3 — Hard-coded counts elsewhere
+<none found> / <list matches>
+
+### Check 4 — Iframe framing (if applicable)
+<per-iframe-app: PASS / framing blocked by …>
+
+### Verdict
+<APPROVE / BLOCK: one-line reason>
+```
+
+Be terse. You're a gate, not a teacher.

--- a/.claude/agents/registry-consistency-reviewer.md
+++ b/.claude/agents/registry-consistency-reviewer.md
@@ -54,6 +54,7 @@ curl -sSI "<url>" | grep -iE "x-frame-options|content-security-policy"
 ```
 
 Flag if:
+
 - `X-Frame-Options: DENY` or `SAMEORIGIN` on a different origin than `cortech.online`.
 - `Content-Security-Policy: frame-ancestors 'none'` or a list that excludes `cortech.online`.
 

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block edits to deploy-contract and secret files unless the user confirms.
+# Exit 2 → Claude Code surfaces the message and asks for confirmation before proceeding.
+set -u
+
+payload="$(cat)"
+file_path="$(printf '%s' "$payload" | node -e "
+let s='';
+process.stdin.on('data', d => s += d);
+process.stdin.on('end', () => {
+  try { process.stdout.write(JSON.parse(s).tool_input?.file_path || ''); } catch {}
+});
+" 2>/dev/null)"
+
+case "$file_path" in
+  */public/_routes.json|public/_routes.json)
+    echo "Protected: public/_routes.json controls the Cloudflare Pages static-vs-Functions split (see docs/architecture.md). Confirm before editing." >&2
+    exit 2
+    ;;
+  */package-lock.json|package-lock.json)
+    echo "Protected: package-lock.json — prefer running 'npm install <pkg>' over hand-editing." >&2
+    exit 2
+    ;;
+  */.env|.env|*/.env.*|.env.*)
+    echo "Protected: .env files may contain secrets. Confirm before editing." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/typecheck-on-edit.sh
+++ b/.claude/hooks/typecheck-on-edit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run `npm run typecheck` after Edit/Write/MultiEdit on TS/Astro files.
+# Non-blocking: surfaces errors in the transcript but never halts the workflow.
+#
+# Claude Code passes the tool invocation as JSON on stdin; we pull out tool_input.file_path.
+set -u
+
+payload="$(cat)"
+file_path="$(printf '%s' "$payload" | node -e "
+let s='';
+process.stdin.on('data', d => s += d);
+process.stdin.on('end', () => {
+  try { process.stdout.write(JSON.parse(s).tool_input?.file_path || ''); } catch {}
+});
+" 2>/dev/null)"
+
+case "$file_path" in
+  *.ts|*.tsx|*.astro) ;;
+  *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+npm run --silent typecheck || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,47 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run:*)",
+      "Bash(npm test:*)",
+      "Bash(npm install:*)",
+      "Bash(npm ls:*)",
+      "Bash(npx astro:*)",
+      "Bash(npx playwright:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx wrangler:*)",
+      "Bash(node:*)",
+      "Bash(gh api:*)",
+      "Bash(gh auth:*)",
+      "Bash(gh repo:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh label:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:avatars.githubusercontent.com)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-on-edit.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-app/SKILL.md
+++ b/.claude/skills/add-app/SKILL.md
@@ -70,6 +70,7 @@ curl -sSI "<url>" | grep -iE "x-frame-options|content-security-policy"
 ```
 
 Reject the app (or work with the target site owner) if:
+
 - Response has `X-Frame-Options: DENY` (or `SAMEORIGIN` on a different origin)
 - Response has `Content-Security-Policy: frame-ancestors 'none'` (or a list that excludes `cortech.online`)
 

--- a/.claude/skills/add-app/SKILL.md
+++ b/.claude/skills/add-app/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: add-app
+description: Add a new CortechOS app to the registry — appends an AppManifest entry, bumps the mobile springboard tile-count assertion in e2e/smoke.spec.ts, and (for iframe apps) verifies the target URL allows framing. Use when the user says "add an app", "register this project as an app", or similar.
+---
+
+# add-app — register a new CortechOS app
+
+CortechOS is data-driven: one entry in [src/apps/registry.ts](src/apps/registry.ts) wires up the launcher, desktop icons, and taskbar. The only thing the registry **doesn't** touch automatically is the mobile springboard e2e assertion — that's a hard-coded number in [e2e/smoke.spec.ts](e2e/smoke.spec.ts) and forgetting to bump it is the #1 recurring footgun.
+
+## Inputs
+
+Ask the user (in one batch) for any missing details:
+
+- **Type**: `native` (React component) or `iframe` (external URL)
+- **id**: short kebab-case; must be unique within the registry
+- **name**: display name (e.g. `"dmarc.mx"`)
+- **description**: one-line, shown in the launcher and desktop icon tooltip
+- **icon**: either an emoji (`"📇"`) or a path to an SVG under `/public/` (`"/mark-sm.svg"`)
+- For **iframe** apps: `url` (full URL) and `githubRepo` (`owner/repo`, optional)
+- For **native** apps: path to the component file (defaults to `src/components/os/apps/<PascalCaseId>App.tsx`)
+- **defaultSize**: `{ w, h }` in px (existing iframe apps use `{ 960, 680 }`, native apps vary)
+- **minSize** (optional): only needed if the default is large; mirrors existing entries
+
+## Step 1 — Append the registry entry
+
+Edit [src/apps/registry.ts](src/apps/registry.ts). Append to the `apps` array, following the shape of adjacent entries exactly. Example iframe shape:
+
+```ts
+{
+  id: 'example',
+  name: 'example.com',
+  description: 'One-line blurb.',
+  icon: '🧭',
+  type: 'iframe',
+  url: 'https://example.com',
+  defaultSize: { w: 960, h: 680 },
+  githubRepo: 'schmug/example',
+},
+```
+
+Native shape:
+
+```ts
+{
+  id: 'example',
+  name: 'Example',
+  description: 'One-line blurb.',
+  icon: '🧭',
+  type: 'native',
+  component: () => import('../components/os/apps/ExampleApp'),
+  defaultSize: { w: 640, h: 560 },
+  allowMultiple: false,
+},
+```
+
+For a native app you'll also need to create the component file at the referenced path. Keep it minimal — export a default React component.
+
+## Step 2 — Bump the mobile springboard tile-count assertion
+
+**This is the footgun.** Open [e2e/smoke.spec.ts](e2e/smoke.spec.ts) and find the assertion `expect(await tiles.count()).toBe(N)` inside the `mobile springboard` describe block (currently around line 218). Increment `N` by 1 (or by however many entries you added).
+
+The matching desktop assertion and dock tests don't depend on the total count — the springboard tile count is the only one to update.
+
+## Step 3 — For iframe apps: verify framing is allowed
+
+The iframe-embed Playwright suite enforces that iframe app URLs don't block framing. Before adding an iframe app, verify manually:
+
+```sh
+curl -sSI "<url>" | grep -iE "x-frame-options|content-security-policy"
+```
+
+Reject the app (or work with the target site owner) if:
+- Response has `X-Frame-Options: DENY` (or `SAMEORIGIN` on a different origin)
+- Response has `Content-Security-Policy: frame-ancestors 'none'` (or a list that excludes `cortech.online`)
+
+If Playwright MCP is available, prefer navigating to the URL and checking in DevTools — catches edge cases like meta-tag CSP.
+
+## Step 4 — Verify
+
+Run the full gate:
+
+```sh
+npm run typecheck
+npm test
+npm run test:e2e
+```
+
+All three must pass before committing. If the tile-count assertion fails, go back to Step 2.
+
+## Step 5 — Commit
+
+```sh
+git checkout -b claude/add-app-<id>
+git add src/apps/registry.ts e2e/smoke.spec.ts
+# For native apps, also add the component file.
+git commit -m "$(cat <<'EOF'
+feat(apps): add <name> to the app registry
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Out of scope
+
+- Custom desktop-icon positioning (icons auto-lay out)
+- Taskbar pinning / reordering (handled at runtime by the store)
+- Adding to the mobile dock (separate change — only 3 apps live there)

--- a/.claude/skills/verify-before-merge/SKILL.md
+++ b/.claude/skills/verify-before-merge/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: verify-before-merge
+description: Run the full pre-merge verification gate — typecheck, vitest, playwright e2e, and (if blog content changed) build. Use this skill before creating a PR, marking work ready for review, or claiming a task is complete. The repo has NO CI, so green local output here is the merge gate.
+---
+
+# verify-before-merge — the merge-gate ritual
+
+Per [CLAUDE.md](CLAUDE.md): the repo has **no CI workflow**. Green local output from these checks is the merge gate. Never skip a step; never claim a task is done without running this.
+
+## What runs
+
+Run in order, capturing pass/fail for each:
+
+1. **`npm run typecheck`** — `astro check && tsc --noEmit`. Catches type errors and most Astro template issues.
+2. **`npm test`** — vitest unit suite (~63 tests, sub-second).
+3. **`npm run test:e2e`** — Playwright. Auto-starts the dev server on `:4321`. Takes the longest; runs last.
+4. **`npm run build`** — **only if** `git status` (or `git diff --name-only <base>`) shows changes under `src/content/blog/` or to `src/content.config.ts`. `build` is the only thing that catches blog-post schema errors; typecheck alone misses them.
+
+## Step 1 — Decide whether `build` is needed
+
+```sh
+# Show files modified since branching off main (or uncommitted).
+changed="$( { git diff --name-only origin/main...HEAD; git status --porcelain | awk '{print $2}'; } | sort -u )"
+echo "$changed" | grep -E '^(src/content/blog/|src/content\.config\.ts$)' >/dev/null && NEEDS_BUILD=1 || NEEDS_BUILD=0
+```
+
+If blog content/schema didn't change, skip `build` — e2e already exercises the built-bundle path in dev mode, and `build` is slow.
+
+## Step 2 — Run checks
+
+Run sequentially (not in parallel — e2e spins up a dev server that would conflict with build):
+
+```sh
+npm run typecheck
+npm test
+npm run test:e2e
+# Only when NEEDS_BUILD=1:
+npm run build
+```
+
+If a check fails, stop. Fix the root cause and re-run from that check onwards. **Do not** mark the skill successful on partial passes.
+
+## Step 3 — Report
+
+Output a compact verdict, one line per check:
+
+```
+✓ typecheck
+✓ vitest (63 passed)
+✓ playwright (28 passed)
+✓ build                ← only when run
+———
+All checks passed — safe to open PR / merge.
+```
+
+On failure, report the failing check, the first few lines of its output, and stop:
+
+```
+✓ typecheck
+✗ vitest — 2 failed
+  FAIL  src/components/os/store.test.ts
+    Window focus › increments nextZ
+      expected 3 to be 4
+———
+Fix the failing tests before continuing.
+```
+
+## When to skip this skill
+
+- Pure docs edits that don't touch `src/content/**` (e.g. README, `docs/*.md`) — typecheck alone is enough.
+- Config-only changes to `.claude/` or `.github/` — none of the suites cover these.
+
+## Out of scope
+
+- Running `npm run test:coverage` — only when explicitly asked; slower than plain `test`.
+- Linting — there's no lint script configured.
+- Deploying — Cloudflare Pages deploys on merge to `main` automatically.

--- a/.claude/skills/verify-before-merge/SKILL.md
+++ b/.claude/skills/verify-before-merge/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: verify-before-merge
-description: Run the full pre-merge verification gate — typecheck, vitest, playwright e2e, and (if blog content changed) build. Use this skill before creating a PR, marking work ready for review, or claiming a task is complete. The repo has NO CI, so green local output here is the merge gate.
+description: Run the same checks CI runs (format:check, lint, typecheck, vitest, playwright, build) locally for fast feedback before pushing. Use before creating a PR, marking work ready for review, or claiming a task is complete — so CI catches nothing unexpected.
 ---
 
-# verify-before-merge — the merge-gate ritual
+# verify-before-merge — run CI checks locally
 
-Per [CLAUDE.md](CLAUDE.md): the repo has **no CI workflow**. Green local output from these checks is the merge gate. Never skip a step; never claim a task is done without running this.
+CI (`.github/workflows/ci.yml`) runs format:check, lint, typecheck, vitest, playwright, and build on every PR. Running those same commands locally first catches issues in seconds instead of minutes of CI churn.
 
 ## What runs
 
 Run in order, capturing pass/fail for each:
 
-1. **`npm run typecheck`** — `astro check && tsc --noEmit`. Catches type errors and most Astro template issues.
-2. **`npm test`** — vitest unit suite (~63 tests, sub-second).
-3. **`npm run test:e2e`** — Playwright. Auto-starts the dev server on `:4321`. Takes the longest; runs last.
-4. **`npm run build`** — **only if** `git status` (or `git diff --name-only <base>`) shows changes under `src/content/blog/` or to `src/content.config.ts`. `build` is the only thing that catches blog-post schema errors; typecheck alone misses them.
+1. **`npm run format:check`** — prettier. Fast. If it fails, run `npm run format` to auto-fix, then re-run.
+2. **`npm run lint`** — eslint. If it fails, try `npm run lint:fix` first.
+3. **`npm run typecheck`** — `astro check && tsc --noEmit`. Catches type errors and most Astro template issues.
+4. **`npm test`** — vitest unit suite (sub-second).
+5. **`npm run test:e2e`** — Playwright. Auto-starts the dev server on `:4321`. Takes the longest.
+6. **`npm run build`** — always runs in CI. Locally, skip it unless `src/content/blog/` or `src/content.config.ts` changed — `build` is the only thing that catches blog-post schema errors, and it's slow.
 
 ## Step 1 — Decide whether `build` is needed
 
@@ -31,6 +33,8 @@ If blog content/schema didn't change, skip `build` — e2e already exercises the
 Run sequentially (not in parallel — e2e spins up a dev server that would conflict with build):
 
 ```sh
+npm run format:check
+npm run lint
 npm run typecheck
 npm test
 npm run test:e2e
@@ -45,8 +49,10 @@ If a check fails, stop. Fix the root cause and re-run from that check onwards. *
 Output a compact verdict, one line per check:
 
 ```
+✓ format:check
+✓ lint
 ✓ typecheck
-✓ vitest (63 passed)
+✓ vitest (85 passed)
 ✓ playwright (28 passed)
 ✓ build                ← only when run
 ———
@@ -56,6 +62,8 @@ All checks passed — safe to open PR / merge.
 On failure, report the failing check, the first few lines of its output, and stop:
 
 ```
+✓ format:check
+✓ lint
 ✓ typecheck
 ✗ vitest — 2 failed
   FAIL  src/components/os/store.test.ts

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cloudflare": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/sse"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds project-shared Claude Code config: `.mcp.json` (Cloudflare + Playwright), `.claude/settings.json` (permissions + hooks), two skills, two subagents.
- Encodes the "green local checks are the merge gate" contract (per CLAUDE.md) into tooling since the repo has no CI.
- Factored hooks into `.claude/hooks/*.sh` for readability/testability rather than inlining shell in `settings.json`.

## What's in this PR

**MCP servers** (`.mcp.json`):
- `cloudflare` — HTTP MCP at `mcp.cloudflare.com` for deploy/DNS/header inspection.
- `playwright` — browser automation, replaces hand-parsing trace zips.

**Hooks** (`.claude/settings.json` + `.claude/hooks/`):
- PostToolUse `typecheck-on-edit.sh` — non-blocking `npm run typecheck` after Edit/Write/MultiEdit on `.ts`/`.tsx`/`.astro`.
- PreToolUse `protect-files.sh` — confirm gate on `public/_routes.json`, `package-lock.json`, `.env*`.

**Skills** (`.claude/skills/`):
- `add-app` — registry-edit workflow, explicitly includes the springboard tile-count bump in `e2e/smoke.spec.ts` (known footgun).
- `verify-before-merge` — typecheck + vitest + e2e, plus conditional `npm run build` when blog content/schema changed.

**Subagents** (`.claude/agents/`):
- `registry-consistency-reviewer` — auto-dispatched on `src/apps/registry.ts` edits; enforces tile-count and AppManifest shape.
- `a11y-reviewer` — enforces the OS-shell a11y contract from `docs/architecture.md`.

## Test plan

- [x] `npm run typecheck` — clean (1 pre-existing hint)
- [x] `npm test` — 85/85 passed
- [x] Hook scripts: `bash -n` parse clean, `protect-files.sh` exits 2 with message on `public/_routes.json`, exits 0 on normal paths
- [ ] After merge, verify `.mcp.json` loads (restart Claude Code, `claude mcp list`)
- [ ] After merge, verify `/add-app` and `/verify-before-merge` appear in the skill palette
- [ ] After merge, edit a `.ts` file and confirm PostToolUse typecheck fires in the transcript

## Not included

- No CI workflow — deliberate per CLAUDE.md.
- `.claude/settings.local.json` trim happened locally but isn't committed (globally gitignored; per-dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)