### PR TITLE
fix(e2e): stabilize playwright against Vite dep-optimizer races

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,23 @@ export default defineConfig({
   trailingSlash: 'ignore',
   vite: {
     plugins: [tailwindcss()],
+    // Pre-bundle deps reached only through lazy-loaded islands (OSShell, MobileShell).
+    // Without this, Vite discovers them on first page load and re-optimizes mid-flight,
+    // returning 504 "Outdated Optimize Dep" on in-flight dynamic imports and flaking e2e.
+    optimizeDeps: {
+      include: ['zustand', 'zustand/middleware', 'react-rnd'],
+    },
+    // Warm up the lazy island entries so Vite's dep crawl completes before the
+    // first browser request — complements optimizeDeps.include above.
+    server: {
+      warmup: {
+        clientFiles: [
+          './src/components/RootShell.tsx',
+          './src/components/os/OSShell.tsx',
+          './src/components/mobile/MobileShell.tsx',
+        ],
+      },
+    },
   },
 
   integrations: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,10 +12,14 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
   webServer: {
-    command: 'npm run dev',
+    // In CI, serve the built site via `astro preview` — no Vite dep optimizer,
+    // so no "504 Outdated Optimize Dep" races on in-flight dynamic islands.
+    // Locally, keep `astro dev` for fast iteration; `optimizeDeps.include` in
+    // astro.config.mjs softens the same race for dev runs.
+    command: process.env.CI ? 'npm run build && npm run preview' : 'npm run dev',
     url: 'http://localhost:4321',
     reuseExistingServer: !process.env.CI,
-    timeout: 60_000,
+    timeout: process.env.CI ? 120_000 : 60_000,
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });


### PR DESCRIPTION
## Summary

- The desktop golden-path e2e intermittently failed in CI with `504 Outdated Optimize Dep` on the dynamic import of `OSShell.tsx`. Vite's dep optimizer was re-bundling mid-flight as it discovered deps reached only through lazy-loaded islands (`zustand`, `zustand/middleware`, `react-rnd`), invalidating in-flight module URLs.
- `astro.config.mjs`: pre-bundle the offending deps via `optimizeDeps.include`, and warm up the island entries (`RootShell`/`OSShell`/`MobileShell`) with `server.warmup.clientFiles` so Vite's crawl completes before the first browser request.
- `playwright.config.ts`: in CI, serve the built site via `astro preview` — no dev optimizer at all, closest to prod. Local dev keeps `astro dev` for fast iteration.

## Why two layers?

`optimizeDeps.include` alone failed on cold caches (reproduced locally 1/5). Adding `server.warmup` closed the dev-mode race too. For CI, switching to `astro preview` eliminates the Vite dep optimizer entirely — the most robust option for the ~12s build cost per run. The dev-mode fixes still help any local `npm run test:e2e` or `npm run dev` session.

## Test plan

- [x] 5× consecutive `CI=1 npm run test:e2e` with `rm -rf node_modules/.vite node_modules/.astro dist` between runs → 5/5 pass (9 tests each, 1 skipped per iframe-embed note)
- [x] 5× consecutive local `npm run test:e2e` with same cold-cache wipe → 5/5 pass (10 tests each)
- [x] `npm run format:check`, `npm run lint`, `npm run typecheck` all green
- [ ] GitHub Actions CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)