### PR TITLE
🎨 Palette: Add visual feedback to copy action in SupportApp

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Using `outline-none` on standard `<input>` elements removes the browser's default focus indicators, making the interface completely inaccessible to keyboard users navigating through forms or search bars. In this application, inputs are often embedded within stylized `div` wrappers (e.g., in ProjectsApp, BlogApp, and Launcher).
 **Action:** Always apply `focus-within` utility classes (like `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]`) to the parent wrapper of any input that uses `outline-none` to restore a highly visible, consistent focus state that matches the application's design system.
+
+## 2025-03-01 - Add Visual Feedback for Background Actions (Clipboard Write)
+
+**Learning:** Background actions like `navigator.clipboard.writeText` are completely invisible to the user. Without explicit visual feedback, users are left wondering if the action succeeded or if they misclicked, leading to redundant clicks and uncertainty. This is especially true for custom UI components that mimic buttons but aren't native `button` elements with built-in active states, or when the action happens silently without navigating away.
+**Action:** Always pair silent background actions (like copying to clipboard, saving preferences, or triggering async processes that don't block UI) with an immediate, temporary visual confirmation state (e.g., changing text to "Copied!", showing a ✅ icon, or a brief toast notification). Ensure the feedback resets after a short delay (e.g., 2 seconds) to return the component to its default state for subsequent uses.

--- a/src/components/os/apps/SupportApp.tsx
+++ b/src/components/os/apps/SupportApp.tsx
@@ -1,8 +1,11 @@
+import { useState, useRef } from 'react';
 import { apps } from '../../../apps/registry';
 import { renderIcon } from '../../../apps/iconUtils';
 
 export default function SupportApp() {
   const flagships = apps.filter((a) => a.type === 'iframe');
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   return (
     <div className="h-full overflow-y-auto bg-[var(--color-void)] px-7 py-6 text-[var(--color-text)]">
@@ -43,13 +46,16 @@ export default function SupportApp() {
           href="https://github.com/schmug?tab=repositories&type=source"
         />
         <Tier
-          icon="🗣️"
+          icon={copied ? '✅' : '🗣️'}
           title="Tell a friend"
           note="If a tool here solved a real problem, share it. Referrals are the best currency."
-          cta="Copy link"
+          cta={copied ? 'Copied!' : 'Copy link'}
           onClick={() => {
             if (typeof navigator !== 'undefined' && navigator.clipboard) {
               navigator.clipboard.writeText('https://cortech.online');
+              setCopied(true);
+              if (timeoutRef.current) clearTimeout(timeoutRef.current);
+              timeoutRef.current = setTimeout(() => setCopied(false), 2000);
             }
           }}
         />
@@ -124,7 +130,7 @@ function Tier(props: {
         <p className="mt-2 text-xs text-[var(--color-muted)]">{props.note}</p>
       </div>
       <div className="mt-3 font-mono text-[11px] text-[var(--color-amber)]">
-        {props.cta} {!props.disabled && '→'}
+        {props.cta} {!props.disabled && props.cta !== 'Copied!' && '→'}
       </div>
     </>
   );


### PR DESCRIPTION
💡 **What**: Added an interactive "Copied!" state and a ✅ icon to the "Tell a friend" copy-to-clipboard action in the Support app.
🎯 **Why**: Background actions like `navigator.clipboard.writeText` are invisible to the user. Without explicit visual feedback, users are left wondering if the action succeeded, which leads to redundant clicks and uncertainty. This gives immediate and clear confirmation.
📸 **Before/After**: The "Copy link" text now changes to "Copied!" with a ✅ icon for 2 seconds when clicked.
♿ **Accessibility**: Provides necessary visual confirmation for an action that has no native feedback.

---
*PR created automatically by Jules for task [368155041140339136](https://jules.google.com/task/368155041140339136) started by @schmug*