### PR TITLE
🎨 Palette: Add focus states to custom search inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Custom Search Inputs Focus State
+**Learning:** The custom search inputs in apps like `ProjectsApp` and `BlogApp` have `outline-none` on the actual `<input>` elements. Since they are wrapped in `div`s styled to look like the input box, keyboard users lose visual focus indication when navigating to these search fields.
+**Action:** Use the `focus-within:` pseudo-class on the parent wrapper `div` to apply border colors and focus rings whenever the child input receives focus. This restores accessible keyboard navigation while keeping the custom UI styling.

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -68,7 +68,7 @@ export default function BlogApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-colors focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -32,7 +32,7 @@ export default function ProjectsApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-colors focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}


### PR DESCRIPTION
**💡 What:** Added a focus state to the search inputs in the Projects and Blog apps.
**🎯 Why:** The inputs are wrapped in custom `div`s and have `outline-none`. Keyboard users had no way of knowing when they had tabbed into the search input.
**♿ Accessibility:** Improves keyboard navigation by providing an active visual focus indicator.

---
*PR created automatically by Jules for task [13427490079503081515](https://jules.google.com/task/13427490079503081515) started by @schmug*