### PR TITLE
🛡️ Sentinel: [MEDIUM] Add standard security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Missing Security Headers on Cloudflare Pages]
+**Vulnerability:** Missing standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Strict-Transport-Security) leaving the site vulnerable to clickjacking, MIME-type sniffing, and downgrade attacks.
+**Learning:** Cloudflare Pages (where this site is deployed) doesn't automatically add standard security headers. We need to manually specify them in a `public/_headers` file to ensure they are applied to static assets.
+**Prevention:** Use a catch-all route `/*` in the `public/_headers` file to enforce these security headers globally for all responses served by Cloudflare Pages.

--- a/public/_headers
+++ b/public/_headers
@@ -6,3 +6,9 @@
   Link: </.well-known/api-catalog>; rel="api-catalog"
   Link: </rss.xml>; rel="alternate"; type="application/rss+xml"
   Link: </sitemap-index.xml>; rel="sitemap"; type="application/xml"
+
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add standard security headers

🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Strict-Transport-Security) leaving the site vulnerable to clickjacking, MIME-type sniffing, and downgrade attacks. Cloudflare Pages doesn't add these automatically.
🎯 Impact: Attackers could potentially frame the site (clickjacking) or intercept traffic if the user doesn't use HTTPS strictly.
🔧 Fix: Added a catch-all route `/*` in `public/_headers` to enforce these headers globally. Also added a journal entry in `.jules/sentinel.md`.
✅ Verification: Ensure the headers are present in the response for any route when deployed to Cloudflare Pages. Tested locally using `pnpm build`.

---
*PR created automatically by Jules for task [1658604093911760992](https://jules.google.com/task/1658604093911760992) started by @schmug*