### PR TITLE
🎨 Palette: Added focus-within states for custom input wrappers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2024-06-25 - Focus-within on custom wrapper inputs
+
+**Learning:** For custom input components (like the search bars in `ProjectsApp` and `BlogApp`) that use `outline-none` on the underlying `<input>` element, it is easy to lose accessibility focus visibility.
+**Action:** Always apply `focus-within` utility classes (e.g. `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]`) to the parent wrapper `div` to maintain visible focus indicators when the user navigates via keyboard.

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -68,7 +68,7 @@ export default function BlogApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -32,7 +32,7 @@ export default function ProjectsApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}


### PR DESCRIPTION
💡 What: Added `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]` to the custom input wrapper `div`s in `ProjectsApp` and `BlogApp`. Also added a journal entry in `.Jules/palette.md` for this learning.
🎯 Why: To maintain accessible and visible focus states for keyboard users. Since the underlying `<input>` elements use `outline-none` for styling purposes, the wrapper div must supply the focus indicator.
♿ Accessibility: Improved keyboard navigation by adding a clear, visible focus state for interactive form elements.

---
*PR created automatically by Jules for task [11816700988106832915](https://jules.google.com/task/11816700988106832915) started by @schmug*