### PR TITLE
⚡ Bolt: optimize app search with pre-computed fields and hoisted lowercasing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-XX-XX - [Safely Optimizing React Render Paths]
+**Learning:** Mutating static/shared objects within a React component or hook render loop (like `useMemo` in `useAllApps`) to compute a derived `_searchable` field is a React anti-pattern and can cause strict mode errors.
+**Action:** When adding pre-computed performance optimizations for static registries, compute them at module load time (in the registry file itself using helpers like `appsRaw.map(withSearchable)`) to ensure the optimized field is safely available synchronously without polluting React render cycles.

--- a/src/apps/registry.ts
+++ b/src/apps/registry.ts
@@ -13,9 +13,19 @@ export type AppManifest = {
   minSize?: { w: number; h: number };
   allowMultiple?: boolean;
   githubRepo?: string;
+  _searchable: string; // Pre-computed search string
 };
 
-export const apps: AppManifest[] = [
+// Internal type for defining apps before _searchable is computed
+type AppManifestRaw = Omit<AppManifest, '_searchable'>;
+
+// Helper to safely pre-compute search strings without mutating during render loops
+const withSearchable = (app: AppManifestRaw): AppManifest => ({
+  ...app,
+  _searchable: `${app.name} ${app.description} ${app.id}`.toLowerCase(),
+});
+
+const appsRaw: AppManifestRaw[] = [
   {
     id: 'about',
     name: 'About Schmug',
@@ -99,3 +109,5 @@ export const apps: AppManifest[] = [
     githubRepo: 'schmug/qr-me',
   },
 ];
+
+export const apps: AppManifest[] = appsRaw.map(withSearchable);

--- a/src/components/os/Launcher.test.tsx
+++ b/src/components/os/Launcher.test.tsx
@@ -6,15 +6,20 @@ import { apps, type AppManifest } from '../../apps/registry';
 import { useOS } from './store';
 
 function makeApp(overrides: Partial<AppManifest> = {}): AppManifest {
-  return {
+  const base = {
     id: 'test-app',
     name: 'Test App',
     description: 'a test',
     icon: 'i',
-    type: 'native',
+    type: 'native' as const,
     component: () => Promise.resolve({ default: () => null as any }),
     defaultSize: { w: 400, h: 300 },
     ...overrides,
+  };
+  return {
+    ...base,
+    _searchable:
+      overrides._searchable ?? `${base.name} ${base.description} ${base.id}`.toLowerCase(),
   };
 }
 

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -11,7 +11,8 @@ type Props = {
 
 export function matches(app: AppManifest, q: string) {
   if (!q) return true;
-  const hay = `${app.name} ${app.description} ${app.id}`.toLowerCase();
+  // Fallback if _searchable is somehow missing (e.g. tests that bypass registry map)
+  const hay = app._searchable ?? `${app.name} ${app.description} ${app.id}`.toLowerCase();
   return hay.includes(q.toLowerCase());
 }
 
@@ -22,7 +23,16 @@ export function Launcher({ open, onClose }: Props) {
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const filtered = useMemo(() => apps.filter((a) => matches(a, query)), [apps, query]);
+  // ⚡ Optimization: Pre-compute lowercase query once per render, avoiding .toLowerCase() inside the filter loop
+  const filtered = useMemo(() => {
+    const qLower = query.toLowerCase();
+    return apps.filter((a) => {
+      if (!qLower) return true;
+      // We expect _searchable to be set. Use direct include for perf.
+      // If matches() is exported and used elsewhere, matches() handles the full logic safely.
+      return (a._searchable ?? `${a.name} ${a.description} ${a.id}`.toLowerCase()).includes(qLower);
+    });
+  }, [apps, query]);
 
   useEffect(() => {
     if (open) {

--- a/src/components/os/store.test.ts
+++ b/src/components/os/store.test.ts
@@ -5,16 +5,21 @@ import type { AppManifest } from '../../apps/registry';
 const noopComponent = () => Promise.resolve({ default: () => null as any });
 
 function makeApp(overrides: Partial<AppManifest> = {}): AppManifest {
-  return {
+  const base = {
     id: 'test-app',
     name: 'Test App',
     description: 'desc',
     icon: 'i',
-    type: 'native',
+    type: 'native' as const,
     component: noopComponent,
     defaultSize: { w: 400, h: 300 },
     allowMultiple: false, // stable ids in tests
     ...overrides,
+  };
+  return {
+    ...base,
+    _searchable:
+      overrides._searchable ?? `${base.name} ${base.description} ${base.id}`.toLowerCase(),
   };
 }
 

--- a/src/hooks/useFeaturedApps.ts
+++ b/src/hooks/useFeaturedApps.ts
@@ -23,6 +23,7 @@ export function featuredRepoToApp(repo: FeaturedRepo): AppManifest {
       ...base,
       type: 'iframe',
       url: repo.homepage,
+      _searchable: `${base.name} ${base.description} ${base.id}`.toLowerCase(),
     };
   }
 
@@ -31,6 +32,7 @@ export function featuredRepoToApp(repo: FeaturedRepo): AppManifest {
     type: 'native',
     component: () => import('../components/os/apps/RepoInfoApp'),
     componentProps: { repo },
+    _searchable: `${base.name} ${base.description} ${base.id}`.toLowerCase(),
   };
 }
 


### PR DESCRIPTION
💡 **What**: The app search optimization involves pre-computing a statically available `_searchable` field on the `AppManifest` at module load time (in `registry.ts`). The `query.toLowerCase()` transformation was then hoisted outside the `.filter` loop in the `<Launcher />` component to avoid repeated calculations.

🎯 **Why**: When a user quickly types in the Launcher to search for an app, the old system recalculated `hay = \`\${app.name} \${app.description} \${app.id}\`.toLowerCase()` and `query.toLowerCase()` for every app in the list, on every keystroke render cycle. 

📊 **Impact**: Reduces string memory allocations and case conversion overhead significantly by converting `O(n)` dynamic strings to an `O(1)` query format with `O(n)` simple substring checks. Expected lower main-thread UI blocking times during fast-typing bursts.

🔬 **Measurement**: Verified the optimization passes all tests including edge-case mock inputs. Monitored through `pnpm run test`, `typecheck`, and `lint`.

---
*PR created automatically by Jules for task [10736382751451244667](https://jules.google.com/task/10736382751451244667) started by @schmug*