### PR TITLE
🛡️ Sentinel: [MEDIUM] Add global security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-22 - [Cloudflare Pages Security Headers]
+**Vulnerability:** Missing global security headers (X-Frame-Options, X-Content-Type-Options, etc.) on the Cloudflare Pages deployment.
+**Learning:** For Cloudflare Pages, security headers aren't added automatically and must be defined explicitly using a catch-all route (`/*`) in the `public/_headers` file.
+**Prevention:** Always include a `/*` block in `public/_headers` to apply basic security measures like HSTS, preventing clickjacking, and mitigating MIME-sniffing across the entire site.

--- a/public/_headers
+++ b/public/_headers
@@ -6,3 +6,9 @@
   Link: </.well-known/api-catalog>; rel="api-catalog"
   Link: </rss.xml>; rel="alternate"; type="application/rss+xml"
   Link: </sitemap-index.xml>; rel="sitemap"; type="application/xml"
+
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
Added global security headers (`X-Content-Type-Options`, `Referrer-Policy`, `Strict-Transport-Security`) to the Cloudflare Pages deployment via `public/_headers`. Created the Sentinel security journal at `.jules/sentinel.md` to document this pattern.

---
*PR created automatically by Jules for task [9235572704094828973](https://jules.google.com/task/9235572704094828973) started by @schmug*