### PR TITLE
🎨 Palette: Implement visible focus states for custom inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Proxy Focus States for Custom Inputs
+**Learning:** In custom input components (like those in ProjectsApp, BlogApp, and Launcher) where the native `<input>` uses `outline-none` for styling purposes, the focus indicator is lost. This is a common accessibility issue. To fix this without breaking the design, the focus state needs to be proxied to the parent wrapper container.
+**Action:** Use `focus-within` utility classes (e.g., `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]`) on the parent `div` to show a visible focus indicator when the child input receives focus. This ensures keyboard accessibility while maintaining the custom design.

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -75,7 +75,7 @@ export function Launcher({ open, onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
         onKeyDown={onKey}
       >
-        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3">
+        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 focus-within:bg-[var(--color-shadow)] transition-colors">
           <span className="font-mono text-xs text-[var(--color-amber)]">›</span>
           <input
             ref={inputRef}

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -68,7 +68,7 @@ export default function BlogApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -32,7 +32,7 @@ export default function ProjectsApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}


### PR DESCRIPTION
💡 What: Added `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]` and `focus-within:bg-[var(--color-shadow)]` styles to the parent wrapper `div`s of custom `<input>` elements in `ProjectsApp`, `BlogApp`, and `Launcher` respectively.

🎯 Why: Custom inputs intentionally removed native focus outlines (`outline-none`) for styling purposes. This severely degraded keyboard accessibility by leaving no visual indicator of focus. By proxying the focus styles to the parent wrapper utilizing Tailwind's `focus-within` utility, we restore critical accessibility while maintaining the intended visual design.

♿ Accessibility: Restored visible focus indicators for custom input fields, ensuring that keyboard-only navigation users can identify the currently active search inputs.

---
*PR created automatically by Jules for task [916938615225572330](https://jules.google.com/task/916938615225572330) started by @schmug*