### PR TITLE
🛡️ Sentinel: [security improvement] Add Security Headers to Cloudflare Pages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-24 - Missing Security Headers in Cloudflare Pages
+**Vulnerability:** The application was missing basic security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Strict-Transport-Security).
+**Learning:** In Cloudflare Pages, these headers aren't added automatically and must be explicitly defined in a `public/_headers` file under a catch-all `/*` route.
+**Prevention:** Always ensure a global `/*` block exists in `public/_headers` applying these baseline defenses.

--- a/public/_headers
+++ b/public/_headers
@@ -6,3 +6,8 @@
   Link: </.well-known/api-catalog>; rel="api-catalog"
   Link: </rss.xml>; rel="alternate"; type="application/rss+xml"
   Link: </sitemap-index.xml>; rel="sitemap"; type="application/xml"
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing basic security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Strict-Transport-Security) since Cloudflare Pages does not add them automatically.
🎯 Impact: This could potentially expose the application to clickjacking, MIME-type sniffing, or downgrade attacks.
🔧 Fix: Added a global `/*` block to `public/_headers` applying these baseline defenses explicitly, and logged this repository-specific detail in the Sentinel Journal.
✅ Verification: Review the `public/_headers` file. Tests pass locally.

---
*PR created automatically by Jules for task [9882086019076388296](https://jules.google.com/task/9882086019076388296) started by @schmug*