### PR TITLE
🎨 Palette: Add focus visibility for custom input components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-04-24 - Focus Visibility for Custom Input Components
+
+**Learning:** Using `outline-none` on standard `<input>` elements removes the browser's default focus indicators, making the interface completely inaccessible to keyboard users navigating through forms or search bars. In this application, inputs are often embedded within stylized `div` wrappers (e.g., in ProjectsApp, BlogApp, and Launcher).
+**Action:** Always apply `focus-within` utility classes (like `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]`) to the parent wrapper of any input that uses `outline-none` to restore a highly visible, consistent focus state that matches the application's design system.

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -75,7 +75,7 @@ export function Launcher({ open, onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
         onKeyDown={onKey}
       >
-        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3">
+        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-xs text-[var(--color-amber)]">›</span>
           <input
             ref={inputRef}

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -68,7 +68,7 @@ export default function BlogApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -32,7 +32,7 @@ export default function ProjectsApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}


### PR DESCRIPTION
**🎨 Palette: UX Improvement**

💡 **What**: Added visible focus indicators (amber border and ring) to custom input wrapper components.
🎯 **Why**: Inputs across the app (Launcher, Projects, Blog) use `outline-none` on the actual `<input>` element to style it cleanly within a custom container. This completely broke keyboard accessibility, as tabbing to the input provided no visual feedback.
📸 **Before/After**: (Verified via Playwright screenshots during pre-commit checks)
♿ **Accessibility**: Restored clear and obvious focus states for keyboard users navigating through the OS shell's core applications and launcher, ensuring compliance with focus visibility guidelines.

A critical UX/accessibility journal entry has been recorded in `.Jules/palette.md` regarding this custom input wrapper pattern.

---
*PR created automatically by Jules for task [15447016320841650570](https://jules.google.com/task/15447016320841650570) started by @schmug*