### PR TITLE
chore: remove Jules agent log files and gitignore them

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,9 +1,0 @@
-## 2026-04-24 - Focus Visibility for Custom Input Components
-
-**Learning:** Using `outline-none` on standard `<input>` elements removes the browser's default focus indicators, making the interface completely inaccessible to keyboard users navigating through forms or search bars. In this application, inputs are often embedded within stylized `div` wrappers (e.g., in ProjectsApp, BlogApp, and Launcher).
-**Action:** Always apply `focus-within` utility classes (like `focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]`) to the parent wrapper of any input that uses `outline-none` to restore a highly visible, consistent focus state that matches the application's design system.
-
-## 2025-03-01 - Add Visual Feedback for Background Actions (Clipboard Write)
-
-**Learning:** Background actions like `navigator.clipboard.writeText` are completely invisible to the user. Without explicit visual feedback, users are left wondering if the action succeeded or if they misclicked, leading to redundant clicks and uncertainty. This is especially true for custom UI components that mimic buttons but aren't native `button` elements with built-in active states, or when the action happens silently without navigating away.
-**Action:** Always pair silent background actions (like copying to clipboard, saving preferences, or triggering async processes that don't block UI) with an immediate, temporary visual confirmation state (e.g., changing text to "Copied!", showing a ✅ icon, or a brief toast notification). Ensure the feedback resets after a short delay (e.g., 2 seconds) to return the component to its default state for subsequent uses.

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ playwright/.cache/
 
 # vitest coverage report
 coverage/
+
+# Jules agent run logs (Palette/Sentinel bots)
+.Jules/
+.jules/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,0 @@
-## 2025-04-24 - Missing Global Security Headers
-
-**Vulnerability:** The Cloudflare Pages deployment lacked global HTTP security headers (like X-Frame-Options, X-Content-Type-Options, etc.), leaving the site potentially vulnerable to clickjacking, MIME-type sniffing, and other basic web attacks.
-**Learning:** In Cloudflare Pages, security headers aren't added automatically. They must be explicitly defined using a catch-all route (`/*`) in the `public/_headers` file.
-**Prevention:** Always ensure a `/*` block exists in `public/_headers` with baseline security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Strict-Transport-Security) for all Cloudflare Pages deployments.


### PR DESCRIPTION
## Summary

- Delete `.Jules/palette.md` and `.jules/sentinel.md` — agent run-log artifacts the Palette/Sentinel bots committed via the PR merge train on 2026-04-25. Not part of the product.
- Add both `.Jules/` and `.jules/` to `.gitignore`. Git matching is case-sensitive on Linux, so list both casings to keep these from coming back.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (85 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)