### PR TITLE
feat(blog): add Rent2Owned three-post series

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Astro dev server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 4321
+    },
+    {
+      "name": "Astro preview (built output)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 4321
+    }
+  ]
+}

--- a/src/content/blog/2026-04-16-rent2owned-the-case.md
+++ b/src/content/blog/2026-04-16-rent2owned-the-case.md
@@ -1,0 +1,109 @@
+---
+title: "Rent2Owned: The Case for Taking Back Our Stack"
+description: "We've been renting the software that runs our lives, and the landlord has broken every rule. Part one of three on owning your stack."
+pubDate: 2026-04-16
+tags: [rent2owned, open-source, sovereignty, surveillance-capitalism, indie]
+draft: false
+---
+
+<!--
+DRAFT - section-by-section. Each heading below is a section to fill in.
+Voice: indie builder (cortech.online register). No antithesis, no
+three-beat tricolons, no throat-clearing, no corporate hedging.
+-->
+
+## I. The open
+
+There's a moment I bet you've had.
+
+You open a tool you've been paying for and a feature you used yesterday is gone. Or the free tier quietly got worse. Maybe the pricing flipped overnight, or a setting that was on is now off and the new default serves the company instead of you.
+
+That little whiff of "wait - I didn't agree to that."
+
+Most of us shrug and move on. I have, for years. There's work to do, and the next small app won't ship itself.
+
+Stack those moments end to end and they stop looking like annoyances. They're a pattern. Software we rely on changes under us, without our consent, to serve somebody else's balance sheet. Our data gets hoovered up and sold back to us as "personalization," and whatever feed or search result we're looking at is tuned by people we'll never meet, for outcomes we don't get a vote on.
+
+We're paying in dollars and in data, and neither buys us a stake.
+
+I'm not trying to sound grandiose. It just feels like the corporations are controlling the individual right now, and not the other way around.
+
+We've been renting.
+
+And the landlord has broken every rule.
+
+## II. Follow the money
+
+Let me skip the hand-wave and show you the receipts.
+
+In 2024, Meta made 97.5% of its revenue from ads. Practically all of it. Google/Alphabet ran 76-78%, booking $64.6 billion from ads in Q2 alone. Amazon's ad business grew 20% year over year to $56.2 billion, its fastest-growing segment. All told, the digital ad industry cleared $259 billion in 2024, up 14.9% on the prior year.
+
+These companies are ad companies with software departments.
+
+Now flip it around. Proton put a number on what one US resident is worth to the major platforms: about $700 a year. Meta alone clocks $217 per US/Canada user. Google clocks around $460 per American searcher. The wholesale price for a row of your basic demographic data is $0.0005 - fifty cents per thousand people. That's the ratio. An industry built around buying and selling you is worth $278 billion, and your zip code fetches a twentieth of a penny on the wholesale side.
+
+The mechanism is real-time bidding. Every time an ad loads, your browser broadcasts a packet of who you are - location, device, interests, inferred demographics - to thousands of potential advertisers, who bid in milliseconds. EPIC puts it at 178 trillion of these auctions a year across the US and Europe. Only one advertiser wins the impression; all of them keep the data. That bidstream is where data brokers get the feed they resell to anyone with a purchase order. ICE, CBP, and FBI have all bought location data sourced from it.
+
+And then the data gets pointed back at you. The FTC's 2024-2025 surveillance-pricing investigation found major retailers using mouse movements, browser history, location, and abandoned carts to set individualized prices. The FTC's own example: a new parent, profiled as such, gets shown higher-priced baby thermometers on page one. You pay for "free" software with your behavior, that behavior gets auctioned in an instant, and the aggregate comes back at you as the price you'll be charged for the next thing you need. You are paying twice - once in data, once in dollars.
+
+The one-liner version: you are not the customer, you are the product, and the receipts are public.
+
+## III. The invisible steering wheel
+
+The data part of this is what most people have heard. The part that doesn't travel as well is that the same systems shaping what you see are quietly picking the decisions you make.
+
+The feed you scroll decides what today's world looks like, and the search results below it decide which facts you'll treat as facts. The product you end up buying, the story you end up reading, the job you apply for, the candidate you vote on - each of those passed through a recommendation layer before it got to you, and that layer is tuned for one thing: your continued engagement. Whether that happens to line up with your actual interests is incidental.
+
+AI researcher Kate Crawford's way of putting it: closed loops are not open to algorithmic auditing, review, or public debate. You can't see the steering, and neither can a regulator, a researcher, or a journalist. Pew Research has pointed at the obvious downstream of that - the algorithms now governing big chunks of our lives are corporate. Built, tuned, and hidden by companies whose incentives are not lined up with yours.
+
+Cambridge Analytica is the example everyone remembers, but it was never really the point. You don't need a scandal for the steering to be happening - it's the default mode.
+
+This is where I stop framing the problem as a privacy problem. Privacy frames it as "they got my info" - a personal harm, a compliance checklist, a cookie banner. What's actually happening is a governance problem sitting under a privacy label. And if you want to go further and call it a democracy problem, I'm with you.
+
+## IV. The pivot
+
+So what do we do about it? The answer is closer than you think.
+
+Open up a random "proprietary" codebase and measure it. Black Duck's 2025 OSSRA audit of 965 commercial codebases found that 97% contain open source components, and 70% of the actual code is open source in origin. The average application has 911 open source components in its dependency tree. In a few industries - EdTech, semiconductors, mobile apps - it's 100%.
+
+You're already using open source. You're just paying a middleman to hide it from you.
+
+When a vendor tells you their "proprietary" stack is safer, ask them for the SBOM. Most of the code they're selling you is the same code they're warning you about. And they aren't doing a great job with it: 91% of vendor-managed codebases have components more than ten versions out of date, and 79% have components with no maintenance activity in twenty-four months. The maintenance premium you're paying for? A lot of it isn't getting done.
+
+Here's what open source actually gives you that proprietary cannot: the ability to audit what you're running, the ability to walk away when the project stops serving you, and a community whose incentives are more lined up with yours than any single vendor's roadmap ever will be.
+
+The "it's messier" objection has it backwards. The mess is the same; the difference is whether you can see it. When a bug is visible in the code, somebody eventually fixes it. Hide the same bug inside a proprietary binary and it ships to production and stays there. Open source doesn't create messiness - it just refuses to hide it.
+
+Governments are already out ahead. Switzerland's EMBAG law made publicly-funded software open-by-default. CISA has leaned into open source as a core part of the US federal cybersecurity posture. The Open Source Initiative has spent years framing this as a global digital commons - infrastructure the way roads are infrastructure, built and maintained in the open because that's what holds it up.
+
+## V. The economics
+
+Every time this comes up, the sticking point is the same: "open source sounds great, but we can't afford to maintain it."
+
+You're already maintaining software - the support contract is just a way to pretend you aren't.
+
+The Linux Foundation's 2025 study on the economic value of open source contributions put hard numbers on the other side of that equation. Active upstream contribution delivers 2-5x ROI. The top 100 contributors generated $23.2 billion in value from $3.9 billion invested between 2018 and 2025 - a 6x return. Forty-nine percent of organizations contribute upstream; forty-five percent maintain private forks that cost hundreds of thousands per year in hidden maintenance the org absorbs silently.
+
+Hilary Carter, who runs research at the Linux Foundation, said the quiet part out loud: "Contribution creates real, measurable value." That's the CFO version. You redirect budget you're already spending - from support contracts that hide the code, to contribution that actually improves the code everybody in your industry is quietly using anyway.
+
+If you want a norm to anchor it, Sentry's OSS Pledge calls for $2,000 per developer per year into upstream maintenance. That's a subscription a small shop can actually track, and rounding error at government scale.
+
+## VI. The close
+
+I'm not going to tell you to rip out your stack. That's not how this works, and it's not how anything that lasts gets built.
+
+What I am going to tell you is that the current arrangement - the one where you pay a landlord to host your own life, your own business, your own data, and your own attention - is a choice. It got made for us by default, and it can be unmade.
+
+I keep coming back to a simpler version of this. It's really about the community - humans controlling their own destiny, not a handful of ad companies doing it quietly on our behalf. Strength in numbers, in openness, in community, instead of the faults we hide inside closed source.
+
+The ask is small. Audit what you already own and what owns you. Pick one tool or service in your stack where the lock-in is starting to cost you something you can see, and go look at the open alternative. Ask your next vendor for an SBOM. If you're a builder, find the library that saved you the most time this year and send its maintainer the cost of a coffee or a commit.
+
+The how - the architecture, the workforce, the objections - is in [the playbook](/blog/rent2owned-the-playbook/). If you want the structured, citable version with all the sources, that's [the thesis](/blog/rent2owned-thesis/).
+
+We've been renting. The door is not locked.
+
+---
+
+*Part one of three. The how is in [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/);
+the full thesis and sources are in [Rent2Owned: The Thesis](/blog/rent2owned-thesis/).
+Published as part of [cortech.online](https://cortech.online).*

--- a/src/content/blog/2026-04-17-rent2owned-the-playbook.md
+++ b/src/content/blog/2026-04-17-rent2owned-the-playbook.md
@@ -1,0 +1,110 @@
+---
+title: "Rent2Owned: The Playbook"
+description: "The why was part one. Here's the how - the architecture, the data, the workforce, the objections, and what to do Monday morning."
+pubDate: 2026-04-17
+tags: [rent2owned, open-source, sovereignty, sovereign-ai, indie]
+draft: false
+---
+
+<!--
+DRAFT - section-by-section. Voice: still indie-builder, but slightly
+more operational than post 1. "The friend who also has a plan."
+No antithesis, no three-beat tricolons, no throat-clearing, no corporate hedging.
+Hyphens only, no en/em dashes.
+-->
+
+## I. The open
+
+The why is in Part 1. This is the how.
+
+If you're walking in with the usual objections - "closed source is safer because attackers can't see the code" or "open source has no funding model" - I hear you. Stay with me anyway. Both of those have aged badly in the last five years, and the countries already doing this have their own receipts to show you.
+
+Here is the playbook, in one pass:
+
+- Write our own code, as a community.
+- Lease our data to the aaS companies on our terms, not theirs.
+- Train AI models to do the work we need, our way, with data we own.
+- Use our collective size and time to solve our actual problems.
+- Build systems that fit our missions instead of the vendor's roadmap.
+- Hire coders to build our own systems, instead of paying support contracts to maintain theirs.
+
+None of this is fringe. Switzerland's EMBAG law already makes publicly-funded software open-by-default, Sweden has spent years building one of the strongest privacy regimes in the world, and the EU is pushing digital sovereignty into procurement, cybersecurity, and public AI infrastructure. If national governments can pivot here, so can your city - and so can you, as a builder.
+
+## II. The architecture
+
+Think about it like building a house. You don't mill the lumber or pour the cement. You pick the supplier, inspect what shows up, and sketch the rooms that actually serve the people living there. Software is the same. There are three layers, and each one wants different governance.
+
+**Layer 1: the commodity layer.** This is the middleware and backend stuff you should never be writing from scratch: databases, auth, queues, caching, runtimes, web frameworks, operating systems. Open source foundations maintain these. You adopt them, you vet them, and if you're a serious operator you contribute back. A one-person shop running on Cloudflare Workers, D1, and R2 is standing on a decade of community work that would cost tens of millions to rebuild in-house. Don't try to own that alone - share the cost with the community that already is.
+
+**Layer 2: the identity layer.** This is the part that is actually yours. Your UX, your workflows, your domain logic, your brand, the seams where your users and your mission meet the software. You do own this, and you should. This is where AI-native builders and small shops have a massive advantage over vendors right now, because you can ship a custom feature in a week that a SaaS product would take six quarters to prioritize. Your identity layer is the thing no vendor will ever build for you, because your users are not their customers.
+
+**Layer 3: the trust layer.** This is the one people skip, and it's the one that bites. The trust layer is how you govern your supply chain - who vets what goes into your stack, how updates roll through, what you pin, what you track, and whether you can reproduce your build on a different machine next year. At minimum: an SBOM, a lockfile you actually read, and a simple written rule for how you take in updates. Dependabot plus signed commits plus a five-line CONTRIBUTING.md gets a small shop 80% of the way there. Skip the trust layer and you are one dependency hijack away from being the lead paragraph of somebody else's incident report.
+
+The split is the whole argument - adopt the commons as your commodity layer, own what makes you different as your identity layer, and wrap both with the supply-chain discipline that keeps the whole thing safe. Miss any of the three and the argument falls apart.
+
+## III. Data sovereignty and AI
+
+Layer 1 and Layer 2 do most of the work, but they miss something on their own. The data moving through your stack is its own question. Who touches it, where it lives, what gets shipped off to vendors - those are architecture questions. You don't bolt privacy on at the end.
+
+Privacy isn't a policy. It's an architecture decision.
+
+For years, making that decision required choosing between "we have AI features" and "we keep our users' data to ourselves." That tradeoff is gone. Open source models - Llama, Mistral, DeepSeek R1 - run on a single modest GPU, a cheap home server, or even a laptop, and they do not phone home. You can run a classifier, a summarizer, a chatbot, or a full RAG pipeline without a single byte of user data leaving your infrastructure. Zero egress is a property of this architecture: the inference happens on hardware you control, and the bytes don't leave.
+
+The DeepSeek controversy is the clean example of why this matters. Hosted DeepSeek sends your prompts to servers operating under Chinese data law. Self-hosted DeepSeek sends nothing anywhere. Same model, same weights, same math, two completely different privacy postures - because the architecture changed. Origin of the weights matters less than where the inference happens.
+
+McKinsey, WEF, IBM, and Stanford HAI have all started calling this "sovereign AI." The short version: you keep operational control of your models and your training data, you avoid vendor dependencies on the inference path, and you can prove all of that to a regulator, an auditor, or a skeptical customer. That is the posture Sweden's privacy regime has been pushing toward for years, and the one the EU is writing into its AI rules.
+
+For an indie builder the math is even simpler. Your users handed you their data because they trust you. Run the models yourself and you keep that trust.
+
+## IV. The workforce
+
+The objection I hear most when I float this playbook is the same one: "we can't hire developers."
+
+The honest state of things first. Junior developer hiring collapsed 67% between 2023 and 2024. The private sector decided AI was a reason to stop training new engineers, and the effects of that decision are going to land hard somewhere between 2029 and 2033. We are watching an industry eat its own junior pipeline in real time.
+
+Here is what that narrative misses. The community did not shrink. GitHub passed 100 million developer accounts in December 2024 and kept going. 97% of commercial codebases already contain open source. Developers who know how to contribute to it are the default demographic of software work. The talent didn't disappear; the hiring pipeline did. Those are different problems.
+
+Government has already quietly figured out how to hire differently. The US Federal Tech Force put 1,000 early-career technologists on payroll in December 2025, accepting GitHub portfolios where a four-year degree used to be the checkbox. OPM cut the federal hire time from over 100 days to under 80. That is the hiring model this playbook depends on: look at what somebody has actually built and committed. Where they went to school is noise.
+
+AI is the force multiplier that makes this work at indie scale. The 2025 Stack Overflow Developer Survey found that 70% of developers using AI coding agents report reduced task time. For a one-person shop, that ratio is the difference between contributing to open source and just consuming it - your part-time contributor, augmented, now ships what a team of four would have shipped in 2019.
+
+And the training loop is already running. Upstream contribution teaches code review, collaboration, security awareness, and the discipline of writing code that someone else will actually have to read. Those are the same skills you would pay a senior developer to coach a junior on. The difference is that the senior is a maintainer in a foreign timezone, and you are paying forward with a few hours of your team's time and the occasional sponsored coffee.
+
+A small shop doesn't need a dev team for its first hire. You need one person, AI-assisted, who can ship to your identity layer and contribute back to the commodity layer underneath it. That person is on GitHub right now. Their resume is a portfolio of pull requests, and you've been handed the wrong form to read.
+
+## V. The objections
+
+If you made it this far, you've probably already argued with some of this in your head. Here is the fast version of every pushback I have heard, with the shortest honest answer I have for each.
+
+| Objection | Short answer |
+|-----------|--------------|
+| "Open source is less secure - attackers can read the code." | Closed source is security through obscurity, which has never held up. CISA's roadmap, Linus's Law, and the Atlantic Council's research on funded OSS all land in the same place: open code gets more scrutiny, and scrutiny is how bugs get found and patched. You can audit open source. You cannot audit your current vendor. |
+| "But vendors warn us open source is risky." | Ask them for their SBOM - the Software Bill of Materials, the ingredient list of every open source component shipped inside their "proprietary" product. 97% of that code is the same stuff they're warning you about. If they can't or won't produce one, that silence is your answer. |
+| "We can't maintain it." | You already are. You're just calling it "support contract" or "SaaS subscription" and not looking inside. Redirect the spend. |
+| "It's messier." | Closed source is not cleaner, it's opaque. Visible problems get fixed; hidden problems ship to production and stay there. |
+| "Who's liable?" | The same governance frame you already use for your vendor stack, applied to the stack you control: contribution policies, SBOMs, update cadence, and a written rule for who signs off on a dependency change. Same risk framework, more transparency. |
+| "We don't have the people." | See the previous section. And: does your current vendor have people who understand your users better than you do? |
+
+Here is the objection I do not have a clean answer for. Maintainer burnout is real, and the open source funding problem is not fully solved. Eghbal's Working in Public lays out the math - a handful of people maintain packages that billions of pieces of software depend on, usually without pay and without backup. We have good patterns now: Sentry's OSS Pledge, GitHub Sponsors, Linux Foundation fiscal hosting, EU-funded OSS audits. None of them, together, fully closes the gap.
+
+The honest answer is that the money already exists. Organizations are paying more to vendors in support contracts and SaaS subscriptions than it would cost to properly fund the open source projects those vendors are quietly built on. Redirect even a fraction of that spend and the maintainers get paid. The plumbing - how that money actually flows from a support-contract line item to a maintainer you've never met - is what we are still figuring out.
+
+## VI. The close
+
+This is where the blog post ends and your week begins. The playbook does not run itself.
+
+Monday morning: audit your stack. Two columns - what you own, and what owns you. Write it down.
+
+This year: pick one commodity-layer dependency you want out of and spend an afternoon mapping what replacing it would cost. Change one thing about your trust layer - an SBOM you can actually produce, a five-line CONTRIBUTING.md, or a dependency-update policy that's a rule instead of a vibe. Contribute back at least once, whether that's a bug report, a docs PR, or the cost of a coffee for a maintainer who saved you a week.
+
+Five years out, what I want is infra by the community and for the community. Thousands of small shops, local governments, and one-person app operators pooling their time, their money, and their patches into shared commodity code that none of them individually owns, while each of them keeps the identity layer and the mission that made them distinct. The plumbing underneath is maintained by everyone who uses it. That is sovereignty.
+
+The why is in [Rent2Owned: The Case](/blog/rent2owned-the-case/). If you want the structured, citable version with every source, that's in [Rent2Owned: The Thesis](/blog/rent2owned-thesis/).
+
+Your move.
+
+---
+
+*Part two of three. The why is in [Rent2Owned: The Case](/blog/rent2owned-the-case/);
+the full thesis and sources are in [Rent2Owned: The Thesis](/blog/rent2owned-thesis/).
+Published as part of [cortech.online](https://cortech.online).*

--- a/src/content/blog/2026-04-18-rent2owned-thesis.md
+++ b/src/content/blog/2026-04-18-rent2owned-thesis.md
@@ -1,0 +1,327 @@
+---
+title: "Rent2Owned: The Thesis"
+description: "The structured, citable companion to Rent2Owned. Claims, evidence, counterarguments, and sources. Forkable under CC-BY-4.0."
+pubDate: 2026-04-18
+tags: [rent2owned, open-source, sovereignty, surveillance-capitalism, thesis]
+draft: false
+---
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Version | 1.0.0 |
+| License | CC-BY-4.0 |
+| Canonical URL | https://cortech.online/blog/rent2owned-thesis/ |
+| Last updated | 2026-04-18 |
+| Status | living document |
+| Companion to | [Rent2Owned: The Case](/blog/rent2owned-the-case/), [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/) |
+
+## Abstract
+
+The dominant commercial software model is extractive: platforms monetize user behavior, shape user decisions through opaque algorithms, and lock customers into dependencies that convert paying users into unpaid maintainers of someone else's product. Open source code, self-hosted AI, and community-governed supply chains make this model unnecessary - the infrastructure already exists, the evidence that it works is already in print, and the only remaining question is whether individuals, organizations, and governments choose it. This document distills that argument into structured claims, evidence, and counterarguments, so it can be cited, forked, and extended.
+
+## Core claims
+
+### 1. The extraction model
+
+**Claim:** The dominant revenue model of dominant consumer platforms is the commodification of human behavior, not the delivery of user value.
+
+**Evidence:**
+
+- Alphabet: 76-78% of total revenue from advertising; $64.6B from ads in a single quarter (SEC filings, 2024).
+- Meta: 97.5% of 2024 revenue from advertising. Reuters (November 2025) reported internal projections of ~$16B/year from scam and banned-goods ad inventory.
+- Amazon: $56.2B in ad revenue in 2024, up 20% year over year and the company's fastest-growing segment.
+- Total digital ad industry: $259B in 2024, up 14.9% (Interactive Advertising Bureau).
+- Proton (2025): approximately $700/year per US resident across major platforms; $217/year per US/Canada user at Meta; ~$460/year per American searcher at Google.
+- Zuboff, S. *The Age of Surveillance Capitalism* (2019) - introduces "surveillance capitalism" and "Big Other" as terms for the distributed architecture of behavioral extraction.
+
+**Counterarguments:**
+
+- *"Ad-supported software provides free access to billions."*
+  Rebuttal: The access is paid for in data and attention, which is measurable in dollars at the per-user level (above). The "free" framing is a marketing artifact.
+- *"Users consent to data collection through Terms of Service."*
+  Rebuttal: Consent to contracts that few users read, covering collection that cannot be opted out of without losing access to modern digital life, is not meaningful consent. Participation in daily life is now the supply chain of surveillance capitalism (Zuboff).
+
+### 2. Algorithmic capture
+
+**Claim:** Opaque algorithms controlled by a small number of private firms govern large portions of public life without the auditability that governance requires.
+
+**Evidence:**
+
+- Kate Crawford (Brookings, *Atlas of AI*): closed loops are not open to algorithmic auditing, review, or public debate.
+- Pew Research Center (2017): the algorithms now governing significant portions of public life are overwhelmingly corporate.
+- Cambridge Analytica (2018): paradigmatic case, but an extreme of a pattern rather than an exception.
+
+**Counterarguments:**
+
+- *"Algorithms improve user experience through personalization."*
+  Rebuttal: Personalization is one effect. The primary optimization target in these systems is engagement and monetization. Users cannot inspect the tradeoff between their interests and the operator's.
+- *"Users can opt out."*
+  Rebuttal: Opt-out controls are partial, gameable, and do not apply to derived or inferred data. Control over visible settings is not control over the underlying model.
+
+### 2a. Surveillance pricing
+
+**Claim:** Personal data collected via surveillance is increasingly used to set individualized prices against the consumer, not only to serve ads.
+
+**Evidence:**
+
+- FTC 6(b) surveillance-pricing study (2024-2025): mouse movements, browser history, location data, and abandoned cart behavior are used as inputs to individualized pricing.
+- FTC example: new parents, profiled as such, are shown higher-priced baby thermometers on page one of retail search results.
+- Companies investigated: Mastercard, Accenture, PROS, Bloomreach, Revionics, McKinsey.
+- 250+ retailer clients across grocery, apparel, health and beauty, home goods, and hardware.
+- Senator Mark Warner (December 2025): consumers "at the mercy of amorphous data brokers capturing their data and using it to determine their maximum financial pain point."
+
+**Counterarguments:**
+
+- *"Differential pricing is efficient market behavior."*
+  Rebuttal: Economic efficiency does not settle the question of informed consent. Consumers cannot see the pricing model, cannot negotiate, and have no mechanism to opt out other than abandoning the transaction entirely.
+
+### 2b. Real-time bidding as mass data leakage
+
+**Claim:** Real-time ad auctions broadcast user data to thousands of bidders, producing a privacy and security vulnerability that extends far beyond advertising.
+
+**Evidence:**
+
+- Electronic Privacy Information Center (EPIC): approximately 178 trillion real-time bidding auctions per year across the US and Europe.
+- Each bid request includes ad identifiers, location, IP address, device details, interests, and demographics, and is broadcast to thousands of potential advertisers.
+- Only one advertiser wins each impression; all participating bidders retain the request data.
+- Bidstream data has been used to track union organizers, identify members of vulnerable populations, and enable warrantless surveillance.
+- ICE, CBP, and FBI have purchased location data sourced from RTB brokers.
+
+**Counterarguments:**
+
+- *"RTB enables efficient advertising markets."*
+  Rebuttal: The market-efficiency argument does not explain why bid-request data is retained and resold outside the auction itself. The leakage is a design choice, not an inherent feature of real-time auctions.
+
+### 3. Vendor lock-in as governance failure
+
+**Claim:** Vendor lock-in is not merely a technical or pricing problem. It is an abdication of governance over the software that runs critical operations.
+
+**Evidence:**
+
+- Springer, "Critical Analysis of Vendor Lock-In and Its Impact on Adoption of Cloud Computing" (2016).
+- Cloud egress fees and interoperability gaps as persistent barriers to exit.
+- 89% multi-cloud adoption alongside continued migration difficulty (BuzzClan, 2026).
+- Cloudflare's public analyses of cloud switching costs.
+
+**Counterarguments:**
+
+- *"Vendors provide reliability and SLAs that in-house teams cannot match."*
+  Rebuttal: Reliability is a property of the system, and community-maintained systems routinely meet or exceed enterprise reliability expectations (Linux, Postgres, Kubernetes, nginx, the BSD family). The vendor is one delivery mechanism for reliability, not the source of it.
+- *"Switching costs are a market reality."*
+  Rebuttal: When switching costs are high enough to prevent ever exiting, the arrangement is not a market transaction. It is a dependency, and dependencies require governance.
+
+### 4. Contribution outperforms extraction
+
+**Claim:** Active upstream contribution to open source produces measurably better returns than passive consumption or private forking.
+
+**Evidence:**
+
+- Linux Foundation, "Economic Value of Open Source Software Contributions" (2025):
+  - 2-5x ROI for active contributors.
+  - Top 100 contributors: $23.2B in measured value from $3.9B invested between 2018 and 2025 (6x return).
+  - 49% of organizations contribute upstream; 45% maintain private forks.
+  - Private forks incur hundreds of thousands of dollars per year per organization in hidden maintenance cost.
+- Hilary Carter, SVP Research, Linux Foundation: "Contribution creates real, measurable value."
+- Sentry's OSS Pledge: $2,000 per developer per year as an emerging industry norm for upstream funding.
+- Eghbal, N. *Working in Public* (2020): economics of maintainer labor and the sustainability gap.
+
+**Counterarguments:**
+
+- *"Contributing upstream exposes proprietary competitive advantage."*
+  Rebuttal: The commodity layer (databases, auth, queues, runtimes, operating systems) is not where competitive advantage lives. Identity-layer advantages remain private while commodity-layer contributions compound across the ecosystem.
+- *"Most organizations lack the capacity to contribute meaningfully."*
+  Rebuttal: Meaningful contribution begins with bug reports, documentation, and CI fixes. The 49% of organizations already contributing are not exclusively large firms with dedicated OSPOs.
+
+### 5. Sovereignty through open source
+
+**Claim:** Open source is the operative mechanism through which individuals, organizations, and governments reclaim control over their software, their data, and the inference performed on that data.
+
+**Evidence:**
+
+- Switzerland: EMBAG legislation (Federal Act on the Use of Electronic Means to Fulfill Government Tasks) makes publicly-funded government software open-by-default.
+- Sweden: sustained data-protection enforcement through Integritetsskyddsmyndigheten (IMY), in addition to GDPR.
+- European Union: digital sovereignty integrated into procurement rules, cybersecurity policy (Cyber Resilience Act), and emerging public AI infrastructure.
+- CISA (US Cybersecurity and Infrastructure Security Agency): Open Source Software Security Roadmap; open-source security posture published as federal guidance.
+- Open Source Initiative: framing of open source as a global digital commons.
+- McKinsey, WEF, IBM, Stanford HAI: independent frameworks for "sovereign AI" converging on the same operational requirements - control over training data, model weights, and inference infrastructure.
+- DeepSeek as the clean architectural example: the hosted endpoint sends prompts to servers operating under Chinese data law; the self-hosted deployment sends nothing anywhere. Same model, same weights, same math, different privacy posture because the architecture changed. Origin of the weights matters less than where the inference happens.
+
+**Counterarguments:**
+
+- *"Open source has its own governance problems - maintainer burnout, funding gaps."*
+  Rebuttal: Valid concern. Funding patterns exist (Sentry's OSS Pledge, GitHub Sponsors, Linux Foundation fiscal hosting, EU-funded OSS audits). The money required is already being spent on vendor support contracts and SaaS subscriptions; redirecting a fraction of that spend closes most of the gap. The unsolved piece is the plumbing that moves money from those line items to maintainers.
+- *"Open source is less secure than closed source."*
+  Rebuttal: Linus's Law (many eyes make shallow bugs), Atlantic Council research on OSS funding and security outcomes, OpenSSF practices, and the raw fact of auditability. Closed source operates on security-through-obscurity, which is not a valid posture.
+
+### 5a. The iceberg fact
+
+**Claim:** Most commercial "proprietary" software is already predominantly open source. The vendor's contribution is packaging, integration, and support, not authorship.
+
+**Evidence:**
+
+- Black Duck / Synopsys 2025 Open Source Security and Risk Analysis (OSSRA), audit of 965 commercial codebases:
+  - 97% of commercial codebases contain open source components.
+  - 70% of the total code base, by volume, is open source in origin.
+  - Average application contains 911 open source components.
+  - In EdTech, semiconductors, and mobile applications: 100%.
+- Vendor-managed maintenance quality (same report):
+  - 91% of vendor-managed codebases contain components more than 10 versions out of date.
+  - 79% contain components with no maintenance activity in the prior 24 months.
+
+**Counterarguments:**
+
+- *"Vendors add integration, support, and compliance value that individual consumers cannot replicate."*
+  Rebuttal: True, and these are services around the code rather than substitutes for the code. Those services can be procured separately through consultancies, managed open source providers, or internal operations teams, without handing over control of the underlying system.
+- *"Origin in open source does not mean customers can adopt open source directly."*
+  Rebuttal: The SBOM test applies. If a customer can inspect the bill of materials, they can make an informed adoption decision. Vendors who decline to disclose the SBOM are the party restricting customer agency.
+
+### 6. The workforce is viable
+
+**Claim:** The "we cannot hire for this" objection reflects a broken hiring pipeline, not an absent workforce. Community-trained, portfolio-evaluated, AI-augmented developers exist and are being hired successfully by governments and small shops.
+
+**Evidence:**
+
+- GitHub: 100M+ developer accounts (December 2024 milestone).
+- US Federal Tech Force (December 2025): 1,000 early-career technologists hired, accepting GitHub portfolios in place of four-year degrees.
+- US Office of Personnel Management (OPM): federal hiring time reduced from over 100 days to under 80.
+- Stack Overflow 2025 Developer Survey: 70% of developers using AI coding agents report reduced task time.
+- Junior developer hiring collapsed 67% between 2023 and 2024 (multiple industry sources) - a private-sector pipeline failure, not an absence of talent.
+- Upstream open source contribution teaches the exact skills most organizations need: code review, collaboration, security awareness, documentation, and the discipline of writing code others must read.
+
+**Counterarguments:**
+
+- *"Governments and indie shops cannot compete with tech-company salaries."*
+  Rebuttal: Salary is one axis of compensation. Mission fit, ownership over the work, and the ability to ship without vendor-roadmap debt are others. The Federal Tech Force and successful indie hires demonstrate competitive viability on the non-salary axes.
+- *"AI will replace developers rather than augment them."*
+  Rebuttal: AI changes the skill mix and the productivity multiplier. Agent usage is reported as enhancement, not substitution (Stack Overflow 2025). Systems still require humans who can own them, read the code, and take responsibility for what the machine produces.
+
+## Calls to action
+
+### For individuals
+
+- Audit what you own and what owns you.
+- Reduce dependence on surveillance-funded platforms when reasonable alternatives exist.
+- Support maintainers financially when you rely on their work.
+- Treat your data as a leased asset, not a free donation.
+
+### For organizations
+
+- Conduct a stack audit by layer: commodity, identity, trust.
+- Establish a written contribution policy, even a short one.
+- Request SBOMs from every vendor. Treat refusal as a data point.
+- Redirect a fraction of support-contract and SaaS spend to upstream maintainer funding.
+- Hire one person who can contribute upstream and customize the identity layer with AI assistance, before hiring a full dev team.
+
+### For governments
+
+- Mandate open-by-default for publicly-funded software (Switzerland EMBAG precedent).
+- Incorporate SBOM requirements and open source support into procurement.
+- Hire via portfolio review rather than credential filters (Federal Tech Force precedent).
+- Fund open source infrastructure audits (EU precedent).
+- Build public AI infrastructure on open weights with domestic inference.
+
+### For developers
+
+- Contribute upstream to the libraries you actually depend on.
+- Publish your portfolio in public; the hiring pipeline is turning toward it.
+- Mentor at least one junior per year, whether inside your organization or through open source review.
+- Build in the open whenever you can.
+
+## Definitions
+
+| Term | Definition |
+|---|---|
+| Surveillance capitalism | The commodification of human behavior as the primary revenue model of dominant consumer software, as defined by Shoshana Zuboff (2019). |
+| Algorithmic capture | The dependence of public and private decision-making on opaque, corporate-controlled algorithmic systems that cannot be externally audited. |
+| Surveillance pricing | Individualized pricing set through inputs derived from user behavior (mouse movements, browser history, location, abandoned carts) rather than market-level inputs. |
+| Real-time bidding (RTB) | Millisecond-scale ad auctions in which user data is broadcast to thousands of potential bidders. Winning bidders buy the impression; all bidders retain the request data. |
+| Digital sovereignty | Operational control over one's data, software, and inference such that jurisdictional, compliance, and governance constraints can be met without vendor permission. |
+| Sovereign AI | Digital sovereignty applied to AI systems: operational control over training data, model weights, and inference infrastructure. |
+| Supply chain governance | Policies and practices that determine what code enters a system, who approves it, how updates are handled, and whether the system can be independently reproduced and audited. |
+| Commodity layer | The middleware and backend components of a system (databases, auth, queues, runtimes, frameworks, operating systems) most efficiently maintained in common. |
+| Identity layer | The application-specific, mission-specific, brand-specific components of a system that distinguish one organization from another. |
+| Trust layer | The governance layer that wraps both commodity and identity layers: SBOMs, contribution policies, update cadence, reproducibility. |
+| SBOM | Software Bill of Materials. A machine-readable inventory of every component in a software product, with versions and licenses. Standards: SPDX, CycloneDX. |
+
+## Bibliography
+
+### Financial receipts (Claim 1)
+
+- Alphabet Inc., SEC filings and 2024 earnings disclosures.
+- Meta Platforms, Inc., SEC filings and 2024 earnings disclosures.
+- Reuters (November 2025), coverage of internal Meta projections on scam ad revenue.
+- Amazon.com, Inc., 2024 earnings disclosures.
+- Interactive Advertising Bureau (IAB), 2024 Digital Advertising Revenue Report.
+- Proton (2025), per-user data value analysis.
+
+### Surveillance and data economics (Claims 2, 2a, 2b)
+
+- Zuboff, Shoshana. *The Age of Surveillance Capitalism.* PublicAffairs, 2019.
+- Federal Trade Commission, 6(b) surveillance-pricing study, 2024-2025.
+- Electronic Privacy Information Center (EPIC), Real-Time Bidding reports.
+- Senator Mark Warner, public statements on surveillance pricing (December 2025).
+
+### Algorithmic accountability (Claim 2)
+
+- Crawford, Kate. *Atlas of AI.* Yale University Press, 2021.
+- Brookings Institution, algorithmic bias research.
+- Pew Research Center, algorithmic transparency reports (2017).
+
+### Open source economics and security (Claims 4, 5, 5a)
+
+- The Linux Foundation, "Economic Value of Open Source Software Contributions" (2025).
+- Black Duck / Synopsys, 2025 Open Source Security and Risk Analysis (OSSRA) report.
+- Atlantic Council, open source security funding research.
+- Open Source Security Foundation (OpenSSF).
+- Cybersecurity and Infrastructure Security Agency (CISA), Open Source Software Security Roadmap.
+- Eghbal, Nadia. *Working in Public.* Stripe Press, 2020.
+- Sentry OSS Pledge.
+
+### Sovereignty and policy (Claim 5)
+
+- Open Source Initiative (OSI), digital commons framing.
+- Switzerland, EMBAG legislation (Federal Act on the Use of Electronic Means to Fulfill Government Tasks).
+- European Union, digital sovereignty and Cyber Resilience Act framework.
+- Integritetsskyddsmyndigheten (IMY, Swedish Data Protection Authority), enforcement history.
+- McKinsey, "Sovereign AI Ecosystems."
+- IBM, "What is AI Sovereignty?"
+- World Economic Forum, "Sovereign AI: Six Ways States Are Building It."
+- Stanford HAI, "AI Sovereignty's Definitional Dilemma."
+
+### Workforce (Claim 6)
+
+- GitHub, Octoverse reports and 100M developer milestone announcement (December 2024).
+- US Office of Personnel Management (OPM), Federal Tech Force announcement and hiring data (December 2025).
+- Stack Overflow 2025 Developer Survey.
+- DORA 2025 report.
+- Industry coverage of 2023-2024 junior-developer hiring collapse.
+
+### Vendor lock-in (Claim 3)
+
+- Springer, "Critical Analysis of Vendor Lock-In and Its Impact on Adoption of Cloud Computing" (2016).
+- BuzzClan (2026), multi-cloud adoption analysis.
+- Cloudflare and Cloud Native Computing Foundation analyses of cloud switching costs.
+
+## Version history
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0.0 | 2026-04-18 | Initial publication. |
+
+## License
+
+This document is released under the Creative Commons Attribution 4.0 International license (CC-BY-4.0).
+
+Fork it. Extend its claims. Challenge its reasoning. Localize it to your jurisdiction. Use it as the scaffold for your own thesis, with attribution. That is the point.
+
+## Companion posts
+
+- [Rent2Owned: The Case for Taking Back Our Stack](/blog/rent2owned-the-case/) - the narrative why.
+- [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/) - the operational how.
+
+---
+
+*Part three of three. Companion to [Rent2Owned: The Case](/blog/rent2owned-the-case/) and [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/).
+Published as part of [cortech.online](https://cortech.online).*


### PR DESCRIPTION
## Summary

- Adds a three-post Rent2Owned series under `/blog/`: a narrative manifesto, an operational playbook, and a structured machine-readable thesis.
- Posts publish on three consecutive dates (2026-04-16 / 17 / 18) so they sort correctly in `/blog/`, `/rss.xml`, and the desktop Blog app.
- Adds `.claude/launch.json` so future Claude sessions can `preview_start` the Astro dev/preview servers by name without re-detecting them.

## What changed

| File | Purpose |
|---|---|
| `src/content/blog/2026-04-16-rent2owned-the-case.md` | Part 1, the narrative why (~1,800 words). Receipts on the ad-revenue economy, surveillance pricing, RTB; pivots through the 97% open-source-iceberg fact into the Linux Foundation contribution-economics math. |
| `src/content/blog/2026-04-17-rent2owned-the-playbook.md` | Part 2, the operational how (~2,350 words). Three-layer architecture (commodity / identity / trust), data sovereignty + self-hosted AI, the workforce reframe, an objections table, and a Monday/this-year/five-years close. |
| `src/content/blog/2026-04-18-rent2owned-thesis.md` | Part 3, the structured thesis. Nine claims with evidence and counterarguments, calls to action by audience, definitions, full bibliography. CC-BY-4.0; designed to be cited and forked by humans and machines. |
| `.claude/launch.json` | Dev-server configs for `preview_start`. |

## Voice direction

These posts are in the indie-builder voice (same register as `2026-04-16-hello-world.md`), not the day-job persona that the source scaffolding leaned on. Drafted section-by-section with explicit guardrails: no "not X, but Y" antithesis cadences, no three-beat tricolons, no throat-clearing, no corporate hedging, and hyphens only (no en/em dashes).

## How it fits the existing pipeline

No code changes. The blog content collection, `/blog/[...slug].astro` detail route, `/blog/index.astro` list, `/rss.xml` merge, and `BlogApp.tsx` desktop card all pick up the three posts automatically.

## Test plan

- [x] `npm run typecheck` - 0 errors, 0 warnings (frontmatter validates against the Zod schema).
- [x] `npm test` - 8 suites / 63 tests passing. The existing `_rss.xml.test.ts` suite covers draft filtering, sort order, the 40-item cap, and category tagging - all three posts inherit `blog` plus their own tags.
- [ ] `npm run dev` and walk:
  - `http://localhost:4321/blog/` shows all three posts, newest first.
  - Each post URL renders cleanly with markdown tables, lists, and inline links.
  - `http://localhost:4321/rss.xml` includes three new `<item>`s, correctly sorted with `<category>` entries.
  - Open the desktop Blog app - the three new posts are searchable by title and tags.
  - Cross-links between posts resolve correctly.
- [ ] `npm run build` succeeds without warnings.

## Out of scope

- Separate `/rent2owned` route or thesis content collection (we deliberately ship Post 3 as a normal blog post).
- A repo-level `LICENSE` file (the CC-BY-4.0 declaration lives inside Post 3).
- Maintainer-funding plumbing - named explicitly in Post 2 and Post 3 as the unsolved part of the argument.