### PR TITLE
🎨 Palette: Improve focus states across inputs and dock buttons

### DIFF
--- a/src/components/mobile/Dock.tsx
+++ b/src/components/mobile/Dock.tsx
@@ -22,7 +22,7 @@ export function Dock() {
               type="button"
               onClick={() => openApp(app.id)}
               aria-label={`Open ${app.name}`}
-              className="flex h-[56px] w-[56px] items-center justify-center rounded-[16px] border border-[var(--color-border)] bg-[var(--color-panel)] text-2xl transition active:scale-95 active:border-[var(--color-amber)]/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+              className="flex h-[56px] w-[56px] items-center justify-center rounded-[16px] border border-[var(--color-border)] bg-[var(--color-panel)] text-2xl transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)] active:scale-95 active:border-[var(--color-amber)]/60"
             >
               <span aria-hidden="true" className="flex items-center justify-center">
                 {renderIcon(app.icon, 'h-7 w-7')}

--- a/src/components/mobile/Dock.tsx
+++ b/src/components/mobile/Dock.tsx
@@ -22,7 +22,7 @@ export function Dock() {
               type="button"
               onClick={() => openApp(app.id)}
               aria-label={`Open ${app.name}`}
-              className="flex h-[56px] w-[56px] items-center justify-center rounded-[16px] border border-[var(--color-border)] bg-[var(--color-panel)] text-2xl transition active:scale-95 active:border-[var(--color-amber)]/60"
+              className="flex h-[56px] w-[56px] items-center justify-center rounded-[16px] border border-[var(--color-border)] bg-[var(--color-panel)] text-2xl transition active:scale-95 active:border-[var(--color-amber)]/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
             >
               <span aria-hidden="true" className="flex items-center justify-center">
                 {renderIcon(app.icon, 'h-7 w-7')}

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -75,7 +75,7 @@ export function Launcher({ open, onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
         onKeyDown={onKey}
       >
-        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
+        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow duration-200">
           <span className="font-mono text-xs text-[var(--color-amber)]">›</span>
           <input
             ref={inputRef}

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -75,7 +75,7 @@ export function Launcher({ open, onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
         onKeyDown={onKey}
       >
-        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow duration-200">
+        <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-xs text-[var(--color-amber)]">›</span>
           <input
             ref={inputRef}

--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -77,7 +77,7 @@ export function Taskbar({ onOpenLauncher }: Props) {
                 else focusWindow(win.id);
               }}
               className={[
-                'flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs transition',
+                'flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]',
                 focused
                   ? 'border-[var(--color-amber)] bg-[var(--color-amber)]/10 text-[var(--color-amber)]'
                   : win.minimized

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -68,7 +68,7 @@ export default function BlogApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow duration-200">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -68,7 +68,7 @@ export default function BlogApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow duration-200">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -32,7 +32,7 @@ export default function ProjectsApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow duration-200">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -32,7 +32,7 @@ export default function ProjectsApp() {
             </span>
           )}
         </div>
-        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)] transition-shadow duration-200">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
             value={query}


### PR DESCRIPTION
💡 What: Added `transition-shadow duration-200` to custom input focus rings, and `focus-visible` outlines to taskbar/dock buttons.
🎯 Why: Custom inputs with `outline-none` felt abrupt when focusing. Taskbar and Dock buttons were completely invisible to keyboard users as they lacked focus indicators.
♿ Accessibility: Ensures users navigating via keyboard can clearly see which app or window is focused in the dock and taskbar.

---
*PR created automatically by Jules for task [4482251690557206795](https://jules.google.com/task/4482251690557206795) started by @schmug*