### PR TITLE
Revert "chore(deps-dev): bump @eslint/js from 9.39.4 to 10.0.1 (#36)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1249,24 +1249,16 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -5329,19 +5321,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Summary

Reverts #36. The `@eslint/js` v9 → v10 bump was incomplete — it raised `@eslint/js` to `^10.0.1` but left `eslint@^9.39.4`, `typescript-eslint@^8.59.0` (peers `eslint@^9`), and `eslint-plugin-astro` on v9. `@eslint/js@10` peerOptional-requires `eslint@^10`, so the tree no longer resolves under strict peer-dep mode.

This unblocks Cloudflare Pages production deploys, which use `npm clean-install` (= `npm ci`, strict). The last 6 main deploys all failed with ERESOLVE since #36 merged on 2026-04-25, so the live site has been frozen at commit `ce9a2f6` and is missing the rent2owned blog series, security headers, palette polish, etc.

GH Actions CI didn't catch this because `npm install` (looser peer-dep behavior in npm 10) tolerated the inconsistency where `npm ci` does not.

## Test plan

- [x] `rm -rf node_modules && npm ci` succeeds (mimics CF Pages)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean (one pre-existing tseslint deprecation hint)
- [x] `npm test` — 85/85 pass
- [x] `npm run build` succeeds
- [ ] CF Pages production deploy goes green after merge → rent2owned posts visible at /blog

Follow-up tracked separately: a proper coordinated `eslint`/`@eslint/js`/`typescript-eslint`/`eslint-plugin-astro` v10 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)