### PR TITLE
⚡ Bolt: cache useProjects hook to prevent redundant requests

### DIFF
--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -17,20 +17,43 @@ export type ProjectsPayload = {
   fetchedAt: string;
 };
 
+// Module-level cache to prevent duplicate requests when multiple
+// components (Desktop, WindowManager, Launcher) mount simultaneously.
+let cachedPayload: ProjectsPayload | null = null;
+let fetchPromise: Promise<ProjectsPayload> | null = null;
+
 export function useProjects() {
-  const [payload, setPayload] = useState<ProjectsPayload | null>(null);
+  const [payload, setPayload] = useState<ProjectsPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/projects.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/projects.json').then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))
+      );
+    }
+
+    fetchPromise
       .then((data: ProjectsPayload) => {
-        if (!cancelled) setPayload(data);
+        if (!cancelled) {
+          cachedPayload = data;
+          setPayload(data);
+        }
       })
       .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'failed to load');
+          fetchPromise = null; // Reset on failure to allow retries
+        }
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 What:
Implemented a module-level cache for the `useProjects` hook to memoize the network request.

🎯 Why:
The application mounts the Desktop, WindowManager, and Launcher simultaneously, and all three of them call `useAllApps()`, which in turn calls `useFeaturedApps()`, which finally calls `useProjects()`. This results in three identical API requests being fired on boot. By hoisting the state to the module level, we deduplicate these requests across the multiple component instances.

📊 Impact:
Reduces API requests for `/api/projects.json` on app load from 3 to 1.

🔬 Measurement:
Start the app. In the Network tab, ensure there is only one request to `projects.json` rather than three duplicate requests.

---
*PR created automatically by Jules for task [16535858482058228399](https://jules.google.com/task/16535858482058228399) started by @schmug*