### PR TITLE
🎨 Palette: Add focus-visible states for Taskbar keyboard navigation

### DIFF
--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -30,7 +30,7 @@ export function Taskbar({ onOpenLauncher }: Props) {
       <button
         type="button"
         onClick={onOpenLauncher}
-        className="group flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)] px-3 py-1.5 text-sm font-semibold text-[var(--color-text)] transition hover:border-[var(--color-amber)] hover:text-[var(--color-amber)]"
+        className="group flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)] px-3 py-1.5 text-sm font-semibold text-[var(--color-text)] transition hover:border-[var(--color-amber)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
         aria-label="Open launcher"
       >
         <svg width="18" height="18" viewBox="0 0 32 32" aria-hidden="true">
@@ -99,7 +99,7 @@ export function Taskbar({ onOpenLauncher }: Props) {
           href="https://github.com/schmug"
           rel="noopener noreferrer"
           target="_blank"
-          className="font-mono text-[11px] text-[var(--color-muted)] transition hover:text-[var(--color-amber)]"
+          className="rounded-sm font-mono text-[11px] text-[var(--color-muted)] transition hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
           title="github.com/schmug"
         >
           /schmug


### PR DESCRIPTION
💡 **What:** Added explicit `focus-visible` styling to the Taskbar interactive elements (the "Open launcher" button and the GitHub link).
🎯 **Why:** The taskbar elements lacked visible focus rings against the dark background, making keyboard navigation difficult for accessibility.
📸 **Before/After:** Verified via Playwright screenshots showing a `var(--color-amber)` outline correctly framing the elements on focus.
♿ **Accessibility:** Ensures keyboard users receive clear visual feedback when interacting with structural OS components without affecting standard mouse or touch states.

---
*PR created automatically by Jules for task [16815306640023096142](https://jules.google.com/task/16815306640023096142) started by @schmug*