### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate simultaneous `useProjects` fetches

### DIFF
--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -17,20 +17,39 @@ export type ProjectsPayload = {
   fetchedAt: string;
 };
 
+// Module-level cache to prevent duplicate fetches when multiple components
+// mount simultaneously and use this hook (e.g., Desktop, WindowManager, Launcher).
+let fetchPromise: Promise<ProjectsPayload> | null = null;
+let cachedPayload: ProjectsPayload | null = null;
+
 export function useProjects() {
-  const [payload, setPayload] = useState<ProjectsPayload | null>(null);
+  const [payload, setPayload] = useState<ProjectsPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/projects.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/projects.json').then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      );
+    }
+
+    fetchPromise
       .then((data: ProjectsPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 **What**: Implemented a module-level cache for the `useProjects` hook that shares an inflight `fetchPromise` and its resulting `cachedPayload` across all components.
🎯 **Why**: Multiple components (like `Launcher`, `Desktop`, and `WindowManager`) mount simultaneously on startup and all call `useProjects()`. Without caching, this spawns duplicate identical API network requests to `/api/projects.json`.
📊 **Impact**: Reduces initial API requests to `/api/projects.json` from N to 1, cutting redundant network traffic and improving initialization performance for all dependent apps.
🔬 **Measurement**: Verify by loading the desktop experience with the network tab open. You should see a single `projects.json` request instead of multiple simultaneous duplicates. Tests successfully verified via `CI=true pnpm test:e2e` and `pnpm test`.

---
*PR created automatically by Jules for task [3526786814937024425](https://jules.google.com/task/3526786814937024425) started by @schmug*