### PR TITLE
🎨 Palette: Add keyboard focus visible states to app components

### DIFF
--- a/src/components/os/apps/AboutApp.tsx
+++ b/src/components/os/apps/AboutApp.tsx
@@ -136,7 +136,7 @@ function LinkCard({
     <a
       href={href}
       {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-      className="group rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-3 transition hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]"
+      className="group rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-3 transition hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
     >
       <div className="flex items-center gap-1.5 font-mono text-[10px] tracking-wider text-[var(--color-muted)] uppercase">
         {icon}

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -116,7 +116,7 @@ export default function BlogApp() {
               <li key={post.slug}>
                 <a
                   href={`/blog/${post.slug}/`}
-                  className="block px-1 py-3 transition hover:bg-[var(--color-panel-hi)]"
+                  className="block rounded-md px-1 py-3 transition hover:bg-[var(--color-panel-hi)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-amber)]"
                 >
                   <div className="flex items-baseline justify-between gap-3">
                     <span className="text-sm font-[var(--font-display)] font-semibold text-[var(--color-text)] hover:text-[var(--color-amber)]">

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -78,7 +78,7 @@ export default function ProjectsApp() {
                   href={repo.html_url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="block px-1 py-2 transition hover:bg-[var(--color-panel-hi)]"
+                  className="block rounded-md px-1 py-2 transition hover:bg-[var(--color-panel-hi)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-amber)]"
                 >
                   <div className="flex items-baseline justify-between gap-3">
                     <span className="font-mono text-sm font-medium text-[var(--color-text)] hover:text-[var(--color-amber)]">

--- a/src/components/os/apps/SupportApp.tsx
+++ b/src/components/os/apps/SupportApp.tsx
@@ -85,7 +85,7 @@ export default function SupportApp() {
                   href={app.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-mono text-[10px] text-[var(--color-muted)] hover:text-[var(--color-amber)]"
+                  className="rounded-sm font-mono text-[10px] text-[var(--color-muted)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
                 >
                   open ↗
                 </a>
@@ -113,7 +113,7 @@ function Tier(props: {
   disabled?: boolean;
 }) {
   const base =
-    'flex h-full flex-col justify-between rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-4 transition';
+    'flex h-full flex-col justify-between rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]';
   const active = 'hover:border-[var(--color-amber)]/60 hover:bg-[var(--color-panel-hi)]';
   const disabled = 'opacity-50 cursor-not-allowed';
   const cls = `${base} ${props.disabled ? disabled : active}`;


### PR DESCRIPTION
🎨 Palette: Add keyboard focus visible states to app components

**💡 What:** 
Added explicit `focus-visible` utility classes to interactive elements like anchor tags and custom cards across `AboutApp`, `SupportApp`, `ProjectsApp`, and `BlogApp`. Also added a `.Jules/palette.md` journal entry regarding this learning.

**🎯 Why:** 
In custom-themed applications with dark or highly customized color palettes (like CortechOS's `var(--color-void)` backgrounds), default browser focus outlines are often invisible or have insufficient contrast. By applying the design system's variables (like `--color-amber`) to focus states, we guarantee accessible keyboard navigation.

**♿ Accessibility:** 
Improves keyboard navigation visibility for users who rely on Tab navigation to interact with links and cards.

---
*PR created automatically by Jules for task [5422432976291354395](https://jules.google.com/task/5422432976291354395) started by @schmug*