### PR TITLE
fix(projects): authenticate GitHub fetch and fail builds loudly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - run: npm test
 
       - run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   e2e:
     name: E2E (Playwright)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Cloudflare Pages:
 | Output directory | `dist`          |
 | Node version     | 22              |
 
+Required build-time env var: **`GITHUB_TOKEN`** — a fine-grained PAT with **public-repo read-only** access (no scopes need to be granted beyond that). The build calls `https://api.github.com/users/schmug/repos` to prerender `/api/projects.json` and the Projects page; without auth, Cloudflare's shared build IPs hit the 60/hr unauthenticated rate limit and the build now fails loudly rather than silently shipping an empty list. Set the var as **encrypted** in Pages → Settings → Environment variables.
+
 `public/_routes.json` ships `{ include: [], exclude: ["/*"] }` so Pages bypasses the Functions runtime entirely — every path is served as a static asset. See [`docs/architecture.md`](docs/architecture.md#deploy-contract) for why.
 
 ## Tech stack

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,30 +1,84 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchOriginalRepos } from './github';
-
-beforeEach(() => {
-  vi.spyOn(console, 'warn').mockImplementation(() => {});
-});
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchAllRepos, fetchOriginalRepos } from './github';
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  delete process.env.GITHUB_TOKEN;
 });
 
-describe('fetchOriginalRepos silent-failure contract', () => {
-  it('returns [] when the API responds non-OK', async () => {
+describe('fetchAllRepos failure contract', () => {
+  it('throws when the API responds non-OK so the build fails loudly', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'rate limited',
+        json: async () => ({}),
+      }),
     );
-    const repos = await fetchOriginalRepos('schmug');
-    expect(repos).toEqual([]);
-    expect(console.warn).toHaveBeenCalled();
+    await expect(fetchOriginalRepos('schmug')).rejects.toThrow(/403/);
   });
 
-  it('returns [] when fetch rejects (network error)', async () => {
+  it('throws when fetch rejects (network error) instead of swallowing it', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
-    const repos = await fetchOriginalRepos('schmug');
-    expect(repos).toEqual([]);
-    expect(console.warn).toHaveBeenCalled();
+    await expect(fetchOriginalRepos('schmug')).rejects.toThrow('network down');
+  });
+});
+
+describe('fetchAllRepos auth header', () => {
+  it('omits Authorization when GITHUB_TOKEN is unset', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+    await fetchAllRepos('schmug');
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('sends Authorization: Bearer when GITHUB_TOKEN is set', async () => {
+    process.env.GITHUB_TOKEN = 'ghp_test123';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+    await fetchAllRepos('schmug');
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer ghp_test123');
+  });
+
+  it('omits the GITHUB_TOKEN hint from error message when authenticated', async () => {
+    process.env.GITHUB_TOKEN = 'ghp_test123';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'forbidden',
+        json: async () => ({}),
+      }),
+    );
+    await expect(fetchAllRepos('schmug')).rejects.toThrow(
+      expect.objectContaining({ message: expect.not.stringContaining('GITHUB_TOKEN') }),
+    );
+  });
+});
+
+describe('fetchAllRepos private-repo defense in depth', () => {
+  it('filters out repos with private: true even though the endpoint should never return them', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { name: 'public-thing', fork: false, archived: false, private: false },
+          { name: 'leaked-private', fork: false, archived: false, private: true },
+          { name: 'no-private-field', fork: false, archived: false },
+        ],
+      }),
+    );
+    const repos = await fetchAllRepos('schmug');
+    const names = repos.map((r) => r.name);
+    expect(names).toContain('public-thing');
+    expect(names).toContain('no-private-field');
+    expect(names).not.toContain('leaked-private');
   });
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -15,27 +15,32 @@ export type Repo = {
   updated_at: string;
   fork: boolean;
   archived: boolean;
+  private?: boolean;
   topics?: string[];
 };
 
 export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const url = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
-  try {
-    const res = await fetch(url, {
-      headers: {
-        'User-Agent': 'cortech.online-portfolio',
-        Accept: 'application/vnd.github+json',
-      },
-    });
-    if (!res.ok) {
-      console.warn(`GitHub API returned ${res.status} for ${username}; returning empty repo list.`);
-      return [];
-    }
-    return (await res.json()) as Repo[];
-  } catch (err) {
-    console.warn(`GitHub API fetch failed for ${username}; returning empty repo list.`, err);
-    return [];
+  const headers: Record<string, string> = {
+    'User-Agent': 'cortech.online-portfolio',
+    Accept: 'application/vnd.github+json',
+  };
+  // Server-only: process.env is never bundled to the client, and this module
+  // is imported only by prerendered routes that run at build time.
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API ${res.status} ${res.statusText} for ${url}` +
+        (token ? '' : ' — set GITHUB_TOKEN to lift the unauthenticated 60/hr rate limit'),
+    );
   }
+  const all = (await res.json()) as Repo[];
+  // /users/{username}/repos returns only public repos, but filter explicitly
+  // so a future endpoint or token-scope change can't accidentally leak private.
+  return all.filter((r) => !r.private);
 }
 
 export async function fetchOriginalRepos(username: string): Promise<Repo[]> {


### PR DESCRIPTION
## Summary

Live `/api/projects.json` was shipping with `repos: []`, so cortech.online's Projects view showed only the manual `school-calendar` fallback. Cloudflare Pages' shared build IPs were hitting GitHub's 60/hr unauthenticated rate limit, and `fetchAllRepos` silently swallowed the 403 into an empty list — the build succeeded, the deploy went out, and the regression was invisible.

Two paired changes:

- **Authenticate the build-time fetch** when `GITHUB_TOKEN` is present. Read via `process.env` (server-only — never bundled to the client) and sent as `Authorization: Bearer …`. Lifts the limit to 5000/hr authenticated. Token is optional in dev/local builds.
- **Throw loudly on any failure** — non-OK response or network error. Removes the silent-degrade pattern that let an empty deploy ship. Error message includes the `GITHUB_TOKEN` hint when the request was unauthenticated.

Defense in depth: explicitly filter `r.private` at the source in `fetchAllRepos` so a future endpoint or token-scope change can't accidentally leak private repos into the static JSON.

CI's `npm run build` step now passes the auto-injected `secrets.GITHUB_TOKEN` so verify jobs don't get rate-limited. README documents the new required env var for Cloudflare Pages: fine-grained PAT (or classic PAT with `public_repo` read), no broader scopes.

Tests inverted from the old silent-failure contract: now assert `throws` on 403 / network error, plus new coverage for Authorization header presence/absence and the private-repo filter.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 89/89 passing, including 6 new/updated tests in `src/lib/github.test.ts`
- [x] Verified `npm run build` *does* now hard-fail with the actionable error message when no token is set and GitHub responds 403 (was previously the silent regression)
- [ ] After merge: confirm live `https://cortech.online/api/projects.json` returns a non-empty `repos` array with current repos
- [ ] After merge: confirm the Projects page on the live site renders all non-fork/non-archived repos again

## Operator action required

Add `GITHUB_TOKEN` as an **encrypted** env var in Cloudflare Pages → Settings → Environment variables. *(User confirmed this is now done — classic PAT with public-repo read scoped to cortech-online.)*

https://claude.ai/code/session_01QAwJ34JC732rN13zxJHzuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAwJ34JC732rN13zxJHzuk)_