### PR TITLE
fix(blog): correct rent2owned cross-post links to use full slug

### DIFF
--- a/src/content/blog/2026-04-16-rent2owned-the-case.md
+++ b/src/content/blog/2026-04-16-rent2owned-the-case.md
@@ -98,12 +98,12 @@ I keep coming back to a simpler version of this. It's really about the community
 
 The ask is small. Audit what you already own and what owns you. Pick one tool or service in your stack where the lock-in is starting to cost you something you can see, and go look at the open alternative. Ask your next vendor for an SBOM. If you're a builder, find the library that saved you the most time this year and send its maintainer the cost of a coffee or a commit.
 
-The how - the architecture, the workforce, the objections - is in [the playbook](/blog/rent2owned-the-playbook/). If you want the structured, citable version with all the sources, that's [the thesis](/blog/rent2owned-thesis/).
+The how - the architecture, the workforce, the objections - is in [the playbook](/blog/2026-04-17-rent2owned-the-playbook/). If you want the structured, citable version with all the sources, that's [the thesis](/blog/2026-04-18-rent2owned-thesis/).
 
 We've been renting. The door is not locked.
 
 ---
 
-*Part one of three. The how is in [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/);
-the full thesis and sources are in [Rent2Owned: The Thesis](/blog/rent2owned-thesis/).
+*Part one of three. The how is in [Rent2Owned: The Playbook](/blog/2026-04-17-rent2owned-the-playbook/);
+the full thesis and sources are in [Rent2Owned: The Thesis](/blog/2026-04-18-rent2owned-thesis/).
 Published as part of [cortech.online](https://cortech.online).*

--- a/src/content/blog/2026-04-17-rent2owned-the-playbook.md
+++ b/src/content/blog/2026-04-17-rent2owned-the-playbook.md
@@ -99,12 +99,12 @@ This year: pick one commodity-layer dependency you want out of and spend an afte
 
 Five years out, what I want is infra by the community and for the community. Thousands of small shops, local governments, and one-person app operators pooling their time, their money, and their patches into shared commodity code that none of them individually owns, while each of them keeps the identity layer and the mission that made them distinct. The plumbing underneath is maintained by everyone who uses it. That is sovereignty.
 
-The why is in [Rent2Owned: The Case](/blog/rent2owned-the-case/). If you want the structured, citable version with every source, that's in [Rent2Owned: The Thesis](/blog/rent2owned-thesis/).
+The why is in [Rent2Owned: The Case](/blog/2026-04-16-rent2owned-the-case/). If you want the structured, citable version with every source, that's in [Rent2Owned: The Thesis](/blog/2026-04-18-rent2owned-thesis/).
 
 Your move.
 
 ---
 
-*Part two of three. The why is in [Rent2Owned: The Case](/blog/rent2owned-the-case/);
-the full thesis and sources are in [Rent2Owned: The Thesis](/blog/rent2owned-thesis/).
+*Part two of three. The why is in [Rent2Owned: The Case](/blog/2026-04-16-rent2owned-the-case/);
+the full thesis and sources are in [Rent2Owned: The Thesis](/blog/2026-04-18-rent2owned-thesis/).
 Published as part of [cortech.online](https://cortech.online).*

--- a/src/content/blog/2026-04-18-rent2owned-thesis.md
+++ b/src/content/blog/2026-04-18-rent2owned-thesis.md
@@ -12,10 +12,10 @@ draft: false
 |---|---|
 | Version | 1.0.0 |
 | License | CC-BY-4.0 |
-| Canonical URL | https://cortech.online/blog/rent2owned-thesis/ |
+| Canonical URL | https://cortech.online/blog/2026-04-18-rent2owned-thesis/ |
 | Last updated | 2026-04-18 |
 | Status | living document |
-| Companion to | [Rent2Owned: The Case](/blog/rent2owned-the-case/), [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/) |
+| Companion to | [Rent2Owned: The Case](/blog/2026-04-16-rent2owned-the-case/), [Rent2Owned: The Playbook](/blog/2026-04-17-rent2owned-the-playbook/) |
 
 ## Abstract
 
@@ -318,10 +318,10 @@ Fork it. Extend its claims. Challenge its reasoning. Localize it to your jurisdi
 
 ## Companion posts
 
-- [Rent2Owned: The Case for Taking Back Our Stack](/blog/rent2owned-the-case/) - the narrative why.
-- [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/) - the operational how.
+- [Rent2Owned: The Case for Taking Back Our Stack](/blog/2026-04-16-rent2owned-the-case/) - the narrative why.
+- [Rent2Owned: The Playbook](/blog/2026-04-17-rent2owned-the-playbook/) - the operational how.
 
 ---
 
-*Part three of three. Companion to [Rent2Owned: The Case](/blog/rent2owned-the-case/) and [Rent2Owned: The Playbook](/blog/rent2owned-the-playbook/).
+*Part three of three. Companion to [Rent2Owned: The Case](/blog/2026-04-16-rent2owned-the-case/) and [Rent2Owned: The Playbook](/blog/2026-04-17-rent2owned-the-playbook/).
 Published as part of [cortech.online](https://cortech.online).*


### PR DESCRIPTION
## Summary

- The three Rent2Owned posts cross-linked to each other using shortened slugs like `/blog/rent2owned-the-case/`, but Astro derives blog routes from the content file id (the filename without `.md`), so the actual URLs include the date prefix: `/blog/2026-04-16-rent2owned-the-case/`.
- Every cross-post link in the trilogy was 404ing, including the canonical URL declared in the thesis metadata table.
- Updated all 11 broken references across the three posts to use the full date-prefixed slug.

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] Manually click through each cross-post link on the deployed preview to confirm chaining works:
  - Case → Playbook, Case → Thesis
  - Playbook → Case, Playbook → Thesis
  - Thesis → Case, Thesis → Playbook
  - Thesis canonical URL resolves

https://claude.ai/code/session_01EP3rTo1m6gwcBg27CJCNno

---
_Generated by [Claude Code](https://claude.ai/code/session_01EP3rTo1m6gwcBg27CJCNno)_