### PR TITLE
fix(build): auto-install stale deps and refuse blank projects.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "node": ">=22.12.0"
   },
   "scripts": {
+    "predev": "node scripts/check-deps.mjs",
     "dev": "astro dev",
+    "prebuild": "node scripts/check-deps.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -1,0 +1,41 @@
+// Run `npm install` only when node_modules is out of date relative to
+// package-lock.json. Wired as `predev`/`prebuild` so a fresh clone or worktree
+// switch can't ship a half-stale tree (see issue #23).
+//
+// Skipped in CI (CI runs `npm ci` explicitly before build), and skipped when
+// `SKIP_DEP_CHECK=1` so escape hatches stay easy.
+
+import { spawnSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+if (process.env.CI || process.env.SKIP_DEP_CHECK) process.exit(0);
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const lockfile = resolve(root, 'package-lock.json');
+const installedLockfile = resolve(root, 'node_modules', '.package-lock.json');
+
+const mtime = (p) => {
+  try {
+    return statSync(p).mtimeMs;
+  } catch {
+    return null;
+  }
+};
+
+const lockMtime = mtime(lockfile);
+if (lockMtime === null) process.exit(0); // no lockfile, nothing to compare against
+
+const installedMtime = mtime(installedLockfile);
+const stale = installedMtime === null || lockMtime > installedMtime;
+
+if (!stale) process.exit(0);
+
+const reason = installedMtime === null ? 'node_modules missing' : 'package-lock.json is newer';
+console.log(`[check-deps] ${reason} — running \`npm install\`…`);
+const result = spawnSync('npm', ['install', '--no-audit', '--no-fund'], {
+  cwd: root,
+  stdio: 'inherit',
+});
+process.exit(result.status ?? 1);

--- a/src/lib/github.buildFeatured.test.ts
+++ b/src/lib/github.buildFeatured.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { FeaturedRepoConfig } from '../apps/featuredRepos';
+import { featuredRepos, type FeaturedRepoConfig } from '../apps/featuredRepos';
 import { buildFeaturedRepos, type Repo } from './github';
 
 const repo = (overrides: Partial<Repo> = {}): Repo => ({
@@ -86,5 +86,17 @@ describe('buildFeaturedRepos', () => {
     const configs: FeaturedRepoConfig[] = [{ fullName: 'schmug/b' }, { fullName: 'schmug/a' }];
     const out = buildFeaturedRepos([repo({ name: 'a' }), repo({ name: 'b' })], configs);
     expect(out.map((r) => r.name)).toEqual(['b', 'a']);
+  });
+
+  // Regression for issue #27: with the production featuredRepos config, an
+  // empty API response silently degrades to only the manual-fallback entries.
+  // Locks in the silent-drop behaviour so any future config change that adds
+  // more manual fallbacks will need to update this assertion deliberately.
+  it('keeps only manual-fallback entries when given an empty repo list', () => {
+    const out = buildFeaturedRepos([], featuredRepos);
+    const survivors = out.map((r) => r.fullName);
+    const expected = featuredRepos.filter((c) => c.manual).map((c) => c.fullName);
+    expect(survivors).toEqual(expected);
+    expect(out.every((r) => r.private === true)).toBe(true);
   });
 });

--- a/src/pages/api/projects.json.ts
+++ b/src/pages/api/projects.json.ts
@@ -3,6 +3,16 @@ import { buildFeaturedRepos, fetchAllRepos } from '../../lib/github';
 
 export const GET: APIRoute = async () => {
   const all = await fetchAllRepos('schmug');
+  // Fail the build instead of shipping a near-blank desktop. An empty list
+  // means we hit GitHub's unauthenticated rate limit (or the user has zero
+  // public repos) — in either case the previous good deploy stays live. See
+  // issue #27.
+  if (all.length === 0) {
+    throw new Error(
+      'fetchAllRepos returned 0 repos — refusing to ship a blank /api/projects.json. ' +
+        'Set GITHUB_TOKEN to lift the unauthenticated 60/hr rate limit.',
+    );
+  }
   const originals = all.filter((r) => !r.fork && !r.archived);
   const repos = originals.map((r) => ({
     name: r.name,


### PR DESCRIPTION
## Summary

Closes two outstanding bugs from the issue tracker — both about builds silently shipping a broken state.

### #23 — Build fails on fresh clone/worktree

`scripts/check-deps.mjs`, wired as `predev`/`prebuild`. Runs `npm install` only when `package-lock.json` is newer than `node_modules/.package-lock.json` (cheap mtime compare). Skipped under `CI=1` (CI runs `npm ci` explicitly) and `SKIP_DEP_CHECK=1` for escape hatches. Verified both paths locally: stale → installs, fresh → no-op, `CI=1` → no-op.

### #27 — Harden build-time GitHub fetch (remaining items)

PR #73 already landed the auth header + throw-on-non-OK. This finishes the issue:

- **`projects.json.ts`**: `throw` when `all.length === 0`. Defense-in-depth on top of #73: even if a future change ever lets `fetchAllRepos` return an empty list cleanly (e.g. user with no public repos, scope tweak), the build now fails instead of publishing a blank desktop.
- **`github.buildFeatured.test.ts`**: regression test against the production `featuredRepos` config that locks in which specific manual-fallback entries survive an empty API response. Pins the silent-drop behaviour so any new manual fallback has to update this assertion deliberately.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 90 passed, including the new `buildFeaturedRepos` regression
- [x] `node scripts/check-deps.mjs` — no-op on fresh tree
- [x] `touch package-lock.json && node scripts/check-deps.mjs` — triggers install
- [x] `CI=1 node scripts/check-deps.mjs` — bails out

`npm run build` exercises the fail-loud path: in this sandbox without `GITHUB_TOKEN`, GitHub returns 403 and the build aborts (existing #73 behaviour, expected).

Closes #23
Closes #27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx4YfW7HTppvS4RRa4PFiE)_