### PR TITLE
🛡️ Sentinel: [Enhancement] Add timeout to GitHub API fetch call

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,11 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: Add timeout to external API calls to prevent build pipeline hangs / DoS
+  const res = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(10000),
+  });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🛡️ Sentinel: [Enhancement] Add timeout to GitHub API fetch call

**Severity:** Enhancement
**Vulnerability:** The prerendering build script (`src/lib/github.ts`) made a `fetch` call to the GitHub API without a timeout configured.
**Impact:** External HTTP requests that lack timeouts can cause the build process/pipeline to hang indefinitely if the third-party API becomes unresponsive or drops packets. This represents a build-time Denial of Service (DoS) vulnerability and can exhaust CI/CD compute resources.
**Fix:** Added `signal: AbortSignal.timeout(10000)` to the `fetch` call in `src/lib/github.ts` to ensure it fails fast securely rather than hanging. Added an explanatory comment. Recorded the learning in `.jules/sentinel.md`.
**Verification:** Ran `pnpm test`, `pnpm lint`, `pnpm typecheck`, and `pnpm test:e2e` to verify the application builds and tests pass successfully with the timeout configuration.

---
*PR created automatically by Jules for task [4511906236845414184](https://jules.google.com/task/4511906236845414184) started by @schmug*