### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout on external fetch call

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,9 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security/Stability: Add timeout to prevent build pipeline hangs or DoS
+  // if GitHub API is unresponsive.
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `fetch` calls to external APIs (`https://api.github.com`) did not specify a timeout.
🎯 Impact: This could result in a denial of service (DoS) or a build pipeline hang if the external service becomes unresponsive.
🔧 Fix: Add `signal: AbortSignal.timeout(10000)` to the fetch call in `src/lib/github.ts` to ensure it fails safely if it hangs. Added a journal entry to `.jules/sentinel.md` documenting this finding.
✅ Verification: Ran unit tests, end-to-end tests, type checks, and linters (all tests pass).

---
*PR created automatically by Jules for task [2786299169158123184](https://jules.google.com/task/2786299169158123184) started by @schmug*