### PR TITLE
🎨 Palette: Use semantic time elements for clocks to prevent screen reader interruption

### DIFF
--- a/src/components/mobile/StatusBar.tsx
+++ b/src/components/mobile/StatusBar.tsx
@@ -18,9 +18,9 @@ export function StatusBar() {
       className="flex h-7 flex-none items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-shadow)]/95 px-4 font-mono text-[10px] tracking-[0.18em] text-[var(--color-muted)] uppercase backdrop-blur"
     >
       <span>CortechOS mobile</span>
-      <span className="text-[var(--color-dim)] tabular-nums" aria-live="polite">
+      <time dateTime={now.toISOString()} className="text-[var(--color-dim)] tabular-nums">
         {formatTime(now)}
-      </span>
+      </time>
     </div>
   );
 }

--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -104,9 +104,12 @@ export function Taskbar({ onOpenLauncher }: Props) {
         >
           /schmug
         </a>
-        <span className="font-mono text-xs text-[var(--color-dim)] tabular-nums" aria-live="polite">
+        <time
+          dateTime={now.toISOString()}
+          className="font-mono text-xs text-[var(--color-dim)] tabular-nums"
+        >
           {formatTime(now)}
-        </span>
+        </time>
       </div>
     </div>
   );


### PR DESCRIPTION
💡 What: Replaced `<span aria-live="polite">` with semantic `<time dateTime={now.toISOString()}>` for the clock components in the Desktop Taskbar and Mobile StatusBar.
🎯 Why: Elements with `aria-live="polite"` cause screen readers to announce changes every time the content updates. For continuously updating clocks, this causes a frustrating and disruptive experience by interrupting the user every minute. Using semantic `<time>` elements provides accessible structure without forcing repetitive announcements.
♿ Accessibility: Eliminates a major source of screen reader interruption while preserving semantic time representation for assistive technologies.

---
*PR created automatically by Jules for task [2251755531838652623](https://jules.google.com/task/2251755531838652623) started by @schmug*