### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to external API fetch calls

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: prevent hangs by timeouting API calls
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,8 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
+      // Security: prevent hangs by timeouting API calls
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
         r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
       );
     }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: prevent build pipeline hangs and DoS vulnerabilities by timeouting external API calls
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External API `fetch` calls lacked timeout configurations, which could lead to application hangs or build pipeline stalls if APIs became unresponsive.
🎯 **Impact:** Stalled build pipelines or degraded application performance (DoS risk).
🔧 **Fix:** Added `signal: AbortSignal.timeout(10000)` to `fetch` requests across the codebase (`src/lib/github.ts`, `src/hooks/useProjects.ts`, `src/components/os/apps/BlogApp.tsx`).
✅ **Verification:** Ran `pnpm build`, `pnpm test`, and `CI=true pnpm test:e2e` to ensure correct functionality and verify no regressions.

*Note: Added a security learning journal entry to `.jules/sentinel.md` outlining the importance of timeouts for fetch calls.*

---
*PR created automatically by Jules for task [13403815525195211440](https://jules.google.com/task/13403815525195211440) started by @schmug*