### PR TITLE
⚡ Bolt: Add module-level caching to BlogApp fetch

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -15,6 +15,11 @@ type BlogPayload = {
   fetchedAt: string;
 };
 
+// Module-level cache to prevent duplicate fetches when the component
+// mounts multiple times (e.g. closing and reopening the BlogApp).
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
@@ -22,20 +27,34 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      );
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 What: Added module-level caching (`fetchPromise` and `cachedPayload`) for the `/api/blog.json` fetch request in `BlogApp.tsx`.
🎯 Why: To solve a performance issue where opening, closing, and reopening the BlogApp window caused redundant API calls and UI flashes while waiting for data that hadn't changed. This leverages the static nature of the API response.
📊 Impact: Reduces network requests by 100% for subsequent BlogApp opens within the same session. Decreases Time To Interactive (TTI) for repeated opens to effectively zero.
🔬 Measurement: Open the BlogApp, check the Network tab to see the initial `blog.json` fetch. Close the app and reopen it - no new fetch will occur, and the data renders instantly.

---
*PR created automatically by Jules for task [1812113323681097730](https://jules.google.com/task/1812113323681097730) started by @schmug*