### PR TITLE
⚡ Bolt: Implement module-level cache for BlogApp data

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -21,21 +21,40 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// Module-level cache to prevent duplicate fetches when multiple components
+// mount simultaneously and use this hook or when the app is opened/closed frequently.
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json').then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      );
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 **What:** Added a module-level caching mechanism (`fetchPromise` and `cachedPayload`) to `src/components/os/apps/BlogApp.tsx`.
🎯 **Why:** The OS shell interface frequently mounts and unmounts application windows. By keeping state inside `BlogApp`, every re-opening of the app triggered a fresh redundant API request to `/api/blog.json` for effectively static content.
📊 **Impact:** Reduces redundant API fetches by exactly 100% after the first cache load. Saves a network roundtrip every time the Blog app is re-opened, contributing to smoother, immediate OS transitions.
🔬 **Measurement:** Open the "Blog" app, close it, and reopen it while observing the Network tab. Previously, this fired multiple API calls; now it caches correctly after the first. All existing tests passing.

---
*PR created automatically by Jules for task [7199183064583099376](https://jules.google.com/task/7199183064583099376) started by @schmug*