### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to all fetch requests to prevent DoS

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: prevent DoS via missing timeouts
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,8 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
+      // Security: prevent DoS via missing timeouts
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
         r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
       );
     }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: prevent DoS/hanging processes via missing timeouts
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Global `fetch` calls to `/api/projects.json`, `/api/blog.json`, and the external GitHub API lacked timeout configurations.
**🎯 Impact:** This exposes the application and build processes to Denial of Service (DoS) risks or hanging server processes if the external endpoints take excessively long to respond.
**🔧 Fix:** Added `signal: AbortSignal.timeout(10000)` to all `fetch` requests across `src/lib/github.ts`, `src/hooks/useProjects.ts`, and `src/components/os/apps/BlogApp.tsx`. Documented learning in `.jules/sentinel.md`.
**✅ Verification:** Ran `pnpm lint`, `pnpm test`, and `pnpm build` successfully to ensure the timeout additions don't break existing builds or data fetching logic.

---
*PR created automatically by Jules for task [5442296514920212647](https://jules.google.com/task/5442296514920212647) started by @schmug*