### PR TITLE
🛡️ Sentinel: Add timeouts to fetch calls to prevent DoS

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: adding timeout to prevent hanging connections and resource exhaustion (DoS)
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,8 +35,9 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      // Security: adding timeout to prevent hanging connections and resource exhaustion (DoS)
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then(
+        (r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))),
       );
     }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: adding timeout to prevent build hangs and external API DoS vectors
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
## Sentinel Security Fix

**Vulnerability:**
External `fetch` calls in React components and build scripts lacked timeout configurations. This creates Denial of Service (DoS) risks where external server hangs or slow networks could permanently hang the application rendering or build process.

**Fix:**
Added `signal: AbortSignal.timeout(10000)` to `fetch` calls in:
- `src/components/os/apps/BlogApp.tsx`
- `src/hooks/useProjects.ts`
- `src/lib/github.ts`

**Verification:**
- Ran `pnpm test` and `pnpm test:e2e` successfully.
- Tested `pnpm typecheck` successfully.

---
*PR created automatically by Jules for task [17151960752777617599](https://jules.google.com/task/17151960752777617599) started by @schmug*