### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout configurations on fetch calls

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: prevent application hangs / DoS by ensuring the request eventually times out
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,8 +35,9 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      // Security: prevent application hangs / DoS by ensuring the request eventually times out
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then(
+        (r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))),
       );
     }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: prevent application hangs / DoS by ensuring the request eventually times out
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix missing timeout configurations on fetch calls

🚨 Severity: MEDIUM
💡 Vulnerability: Multiple `fetch` calls across the codebase lacked timeout configurations.
🎯 Impact: Without timeouts, these requests could hang indefinitely if the server is unresponsive or slow, leading to application hangs and potential Denial of Service (DoS) vulnerabilities on both client and build-time prerendering.
🔧 Fix: Added `signal: AbortSignal.timeout(10000)` to the vulnerable `fetch` calls in `src/lib/github.ts`, `src/components/os/apps/BlogApp.tsx`, and `src/hooks/useProjects.ts`.
✅ Verification: `pnpm build` and `pnpm test` successfully completed without hanging.

---
*PR created automatically by Jules for task [8092069003503176568](https://jules.google.com/task/8092069003503176568) started by @schmug*