### PR TITLE
⚡ Bolt: Add module-level caching for BlogApp

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -15,6 +15,11 @@ type BlogPayload = {
   fetchedAt: string;
 };
 
+// Module-level cache to prevent duplicate fetches when multiple instances
+// of BlogApp mount, reducing network requests and improving load time.
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
@@ -22,20 +27,35 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      // ⚡ Bolt Optimization: Add abort signal timeout to prevent DoS/hangs
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      );
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,8 +35,9 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      // ⚡ Bolt Optimization: Add abort signal timeout to prevent DoS/hangs
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then(
+        (r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))),
       );
     }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // ⚡ Bolt Optimization: Add abort signal timeout to prevent DoS/hangs
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
💡 **What:** 
- Implements a module-level cache for `/api/blog.json` in `BlogApp.tsx`.
- Adds `AbortSignal.timeout(10000)` to `fetch` requests across `BlogApp.tsx`, `useProjects.ts`, and `github.ts`.

🎯 **Why:** 
When the user opens multiple instances of `BlogApp` (or remounts it quickly via window manager), React triggers duplicate network requests for the same semi-static data payload. Caching the Promise globally deduplicates these requests. Additionally, unbound `fetch` calls leave the React application vulnerable to indefinite hangs if the network is flaky.

📊 **Impact:** 
- Reduces duplicate `/api/blog.json` payload network requests by 100% on subsequent remounts or simultaneous renders.
- Prevents indefinite Promise hangs, releasing React suspense/loading states within 10 seconds max. 

🔬 **Measurement:** 
Open the application in dev mode, open the network tab, and rapidly open 5 instances of the Blog app via the taskbar. Previously, this would trigger 5 identical `fetch` requests. Now, it will only trigger 1 request. Additionally, artificially delaying the API response beyond 10s will now reliably trigger the fallback error UI rather than hanging indefinitely.

---
*PR created automatically by Jules for task [11360143037787946840](https://jules.google.com/task/11360143037787946840) started by @schmug*