### PR TITLE
🛡️ Sentinel: Add timeouts to fetch requests

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,7 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,7 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
         r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
       );
     }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,7 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
Adds a robust 10-second timeout to all `fetch` requests across the application using `AbortSignal.timeout(10000)`.

This addresses a medium-severity security and resilience issue:
- In `src/lib/github.ts` (SSR build process), an unresponsive GitHub API could previously cause the prerendering phase to hang indefinitely.
- In `src/components/os/apps/BlogApp.tsx` and `src/hooks/useProjects.ts`, client-side fetches lacked timeouts, which could freeze components or cause poor UX on slow networks.

All checks (`pnpm test`, `pnpm lint`, `pnpm build`, and `pnpm test:e2e`) are passing.

---
*PR created automatically by Jules for task [5705057277548815785](https://jules.google.com/task/5705057277548815785) started by @schmug*