### PR TITLE
🛡️ Sentinel: Add explicit timeouts to fetch requests

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security enhancement: Add a 10s timeout to prevent DoS via hanging requests
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,8 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
+      // Security enhancement: Add a 10s timeout to prevent DoS via hanging requests
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
         r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
       );
     }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security enhancement: Add a 10s timeout to prevent DoS via hanging requests
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add timeout configurations to global API fetch calls

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Global fetch calls across components and API libraries lacked explicit timeouts, leading to potential DoS risks or application hangs from indefinitely delayed responses.
🎯 **Impact**: If an internal API endpoint (like `/api/blog.json`) or an external API (like `api.github.com`) hangs and fails to respond, the application promise will block indefinitely, causing hanging UI states or failed background fetches.
🔧 **Fix**: Implemented defense-in-depth by adding a 10s timeout (`signal: AbortSignal.timeout(10000)`) to all global `fetch` operations to prevent blocking threads.
✅ **Verification**: Run `pnpm test` and `pnpm lint` to ensure stability. No functional changes occurred; application fails securely if a timeout happens.

---
*PR created automatically by Jules for task [14529616724112407526](https://jules.google.com/task/14529616724112407526) started by @schmug*