### PR TITLE
🎨 Palette: Improve clock accessibility

### DIFF
--- a/src/components/mobile/StatusBar.tsx
+++ b/src/components/mobile/StatusBar.tsx
@@ -18,9 +18,9 @@ export function StatusBar() {
       className="flex h-7 flex-none items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-shadow)]/95 px-4 font-mono text-[10px] tracking-[0.18em] text-[var(--color-muted)] uppercase backdrop-blur"
     >
       <span>CortechOS mobile</span>
-      <span className="text-[var(--color-dim)] tabular-nums" aria-live="polite">
+      <time dateTime={now.toISOString()} className="text-[var(--color-dim)] tabular-nums">
         {formatTime(now)}
-      </span>
+      </time>
     </div>
   );
 }

--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -104,9 +104,12 @@ export function Taskbar({ onOpenLauncher }: Props) {
         >
           /schmug
         </a>
-        <span className="font-mono text-xs text-[var(--color-dim)] tabular-nums" aria-live="polite">
+        <time
+          dateTime={now.toISOString()}
+          className="font-mono text-xs text-[var(--color-dim)] tabular-nums"
+        >
           {formatTime(now)}
-        </span>
+        </time>
       </div>
     </div>
   );


### PR DESCRIPTION
Replaces `aria-live="polite"` with semantic `<time dateTime="...">` elements on the system clocks in both the desktop `Taskbar.tsx` and mobile `StatusBar.tsx` to prevent screen readers from constantly announcing minute-by-minute updates.

---
*PR created automatically by Jules for task [4643126622803699860](https://jules.google.com/task/4643126622803699860) started by @schmug*