### PR TITLE
⚡ Bolt: cache blog fetch for instant open

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -21,21 +21,40 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// Module-level cache to deduplicate fetches when the app component mounts/unmounts
+// frequently during window open/close operations.
+// Expected Impact: 100% reduction in network requests on subsequent opens, instant loads.
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))));
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 **What:** Added a module-level cache (`fetchPromise` and `cachedPayload`) to `BlogApp.tsx`.
🎯 **Why:** In the OS-like interface, opening and closing apps unmounts the component, causing the local `useEffect` to fetch data anew every time.
📊 **Impact:** Reduces network requests by 100% on subsequent opens of the Blog app, allowing it to load instantly from memory instead of hitting the network.
🔬 **Measurement:** Open the "Blog" app, close it, and open it again. There will be no second network request in the DevTools Network tab, and the UI will paint immediately. Run `pnpm test` to verify no regressions in functionality.

---
*PR created automatically by Jules for task [11050106541366329621](https://jules.google.com/task/11050106541366329621) started by @schmug*