### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to fetch APIs

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: Add timeout to prevent application hangs and DoS vulnerabilities from stalled connections
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,8 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
+      // Security: Add timeout to prevent application hangs and DoS vulnerabilities from stalled connections
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
         r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
       );
     }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: Add timeout to prevent application hangs and DoS vulnerabilities from stalled connections
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing timeouts on generic fetch calls in both client components and server build scripts.
🎯 Impact: Without a timeout, a stalled network connection to the `/api/blog.json`, `/api/projects.json`, or the external GitHub API could hang the fetch promise indefinitely, leading to resource exhaustion or application unresponsiveness.
🔧 Fix: Added `signal: AbortSignal.timeout(10000)` to all standalone fetch calls.
✅ Verification: Application successfully builds and passes all tests.

---
*PR created automatically by Jules for task [3269836931555242452](https://jules.google.com/task/3269836931555242452) started by @schmug*