### PR TITLE
⚡ Bolt: Implement module-level cache for BlogApp data fetching

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -21,21 +21,39 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// Module-level cache to prevent duplicate fetches across component mounts
+// Since windowed OS apps frequently unmount, this saves network trips
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))));
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 What: Introduced a module-level cache (`fetchPromise` and `cachedPayload`) in `BlogApp.tsx`.
🎯 Why: In the windowed UI architecture, components frequently mount and unmount when opened and closed. Previously, the app fetched `/api/blog.json` in a `useEffect` on every mount, causing redundant network requests and a visible loading state every time the user reopened the Blog app.
📊 Impact: Reduces network requests to exactly 1 per session for the Blog payload, resulting in instant loads on subsequent app opens.
🔬 Measurement: Verified with `pnpm test` and `pnpm lint`. The caching logic prevents unnecessary state transitions and network trips.

---
*PR created automatically by Jules for task [2658475653760629607](https://jules.google.com/task/2658475653760629607) started by @schmug*