### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to fetch calls to prevent DoS

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: prevent DoS via infinite hang on external API requests
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,8 +35,9 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      // Security: prevent DoS via infinite hang on external API requests
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then(
+        (r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))),
       );
     }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: prevent DoS via infinite hang on external API requests
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add timeouts to fetch calls to prevent DoS

🚨 Severity: MEDIUM
💡 Vulnerability: External API requests (GitHub) and internal data fetches lacked timeouts. If the server is unresponsive or slowly draining data, `fetch` can hang indefinitely, leading to resource exhaustion or application hangs (Denial of Service).
🎯 Impact: An attacker could potentially exhaust serverless function resources or freeze the application by targeting the lack of timeouts.
🔧 Fix: Added `signal: AbortSignal.timeout(10000)` to `fetch` calls in `src/lib/github.ts`, `src/hooks/useProjects.ts`, and `src/components/os/apps/BlogApp.tsx`. Added security comments.
✅ Verification: Verify that the `AbortSignal.timeout(10000)` is present in the `fetch` calls within the modified files.

---
*PR created automatically by Jules for task [16787012017910342510](https://jules.google.com/task/16787012017910342510) started by @schmug*