### PR TITLE
🎨 Palette: [UX/a11y improvements] Add Launcher Clear Button & Fix Clock Aria-Live

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Replace aria-live with Semantic Time Elements
+**Learning:** Using `aria-live="polite"` on continuously updating components (like taskbar clocks) creates a poor experience by constantly interrupting screen readers.
+**Action:** Always prefer semantic `<time dateTime={...}>` elements over generic `<span>` elements with `aria-live` for continuously updating time displays.

--- a/src/components/mobile/StatusBar.tsx
+++ b/src/components/mobile/StatusBar.tsx
@@ -18,9 +18,9 @@ export function StatusBar() {
       className="flex h-7 flex-none items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-shadow)]/95 px-4 font-mono text-[10px] tracking-[0.18em] text-[var(--color-muted)] uppercase backdrop-blur"
     >
       <span>CortechOS mobile</span>
-      <span className="text-[var(--color-dim)] tabular-nums" aria-live="polite">
+      <time dateTime={now.toISOString()} className="text-[var(--color-dim)] tabular-nums">
         {formatTime(now)}
-      </span>
+      </time>
     </div>
   );
 }

--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -77,17 +77,45 @@ export function Launcher({ open, onClose }: Props) {
       >
         <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-panel-hi)] px-4 py-3 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-xs text-[var(--color-amber)]">›</span>
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search apps…"
-            className="flex-1 bg-transparent text-sm text-[var(--color-text)] outline-none placeholder:text-[var(--color-muted)]"
-            aria-label="Search apps"
-            autoComplete="off"
-            spellCheck={false}
-            maxLength={100} // Security: prevent DoS via extremely long input strings
-          />
+          <div className="relative flex flex-1 items-center">
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search apps…"
+              className="w-full bg-transparent pr-6 text-sm text-[var(--color-text)] outline-none placeholder:text-[var(--color-muted)]"
+              aria-label="Search apps"
+              autoComplete="off"
+              spellCheck={false}
+              maxLength={100} // Security: prevent DoS via extremely long input strings
+            />
+            {query.length > 0 && (
+              <button
+                type="button"
+                aria-label="Clear search"
+                className="absolute right-0 flex items-center justify-center rounded-sm p-1 text-[var(--color-muted)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+                onClick={() => {
+                  setQuery('');
+                  inputRef.current?.focus();
+                }}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            )}
+          </div>
           <span className="font-mono text-[10px] text-[var(--color-muted)]">Esc</span>
         </div>
 

--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -104,9 +104,12 @@ export function Taskbar({ onOpenLauncher }: Props) {
         >
           /schmug
         </a>
-        <span className="font-mono text-xs text-[var(--color-dim)] tabular-nums" aria-live="polite">
+        <time
+          dateTime={now.toISOString()}
+          className="font-mono text-xs text-[var(--color-dim)] tabular-nums"
+        >
           {formatTime(now)}
-        </span>
+        </time>
       </div>
     </div>
   );


### PR DESCRIPTION
🎨 **Palette: [UX/a11y improvements] Add Launcher Clear Button & Fix Clock Aria-Live**

💡 **What:** 
- Switched generic `<span>` wrapper on taskbar and mobile status clocks to semantic `<time dateTime={...}>` elements and removed `aria-live="polite"`.
- Added an explicit "Clear search" icon button to the `Launcher.tsx` search input that resets the input and properly restores focus.
- Started the `palette.md` journal.

🎯 **Why:** 
- The `aria-live` attribute on clocks interrupts screen readers every minute with time updates, creating a deeply frustrating accessibility experience. Using semantic `<time>` tags provides the exact same utility without the interruptive verbosity.
- Users had no way to instantly clear the search bar in the Launcher interface beyond backspacing, leaving the input field frustrating for repeated searches. 

📸 **Before/After:**
- Launcher clear button explicitly tested via local Playwright screenshot.
- Focus properly jumps back to the input box upon hitting clear.

♿ **Accessibility:** 
- Removed interruptive `aria-live` updates in favor of semantic `<time>` elements. 
- The clear button was built with full keyboard accessibility in mind (can tab into it, `focus-visible` ring utilizes the system `--color-amber` accent), and explicit `aria-label="Clear search"` exists.

---
*PR created automatically by Jules for task [13455149525788428849](https://jules.google.com/task/13455149525788428849) started by @schmug*