### PR TITLE
⚡ Bolt: Module-level caching for Blog data

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -21,21 +21,45 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// Module-level cache to prevent duplicate fetches when the component
+// unmounts and remounts (e.g., when the blog window is closed and reopened).
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .then((data: BlogPayload) => {
+          cachedPayload = data;
+          return data;
+        })
+        .catch((err) => {
+          fetchPromise = null; // Allow retry on error
+          throw err;
+        });
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 What: Added module-level caching variables (`fetchPromise` and `cachedPayload`) to `BlogApp.tsx` to handle the JSON data fetch.
🎯 Why: In the windowed OS architecture, components unmount when closed, which wiped their local state and caused the component to fetch the static `/api/blog.json` file over the network every single time the user opened the Blog app.
📊 Impact: Eliminates 100% of redundant API calls for the blog content after the first open, enabling instant zero-latency loads on subsequent window interactions.
🔬 Measurement: Verify by booting the OS, opening the Blog app, closing it, and opening it again—the second load should happen immediately without any network requests hitting the browser's dev tools network panel.

---
*PR created automatically by Jules for task [3345225327533789657](https://jules.google.com/task/3345225327533789657) started by @schmug*