### PR TITLE
🎨 Palette: Improve accessibility of clock components

### DIFF
--- a/src/components/mobile/StatusBar.tsx
+++ b/src/components/mobile/StatusBar.tsx
@@ -18,9 +18,9 @@ export function StatusBar() {
       className="flex h-7 flex-none items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-shadow)]/95 px-4 font-mono text-[10px] tracking-[0.18em] text-[var(--color-muted)] uppercase backdrop-blur"
     >
       <span>CortechOS mobile</span>
-      <span className="text-[var(--color-dim)] tabular-nums" aria-live="polite">
+      <time className="text-[var(--color-dim)] tabular-nums" dateTime={now.toISOString()}>
         {formatTime(now)}
-      </span>
+      </time>
     </div>
   );
 }

--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -104,9 +104,9 @@ export function Taskbar({ onOpenLauncher }: Props) {
         >
           /schmug
         </a>
-        <span className="font-mono text-xs text-[var(--color-dim)] tabular-nums" aria-live="polite">
+        <time className="font-mono text-xs text-[var(--color-dim)] tabular-nums" dateTime={now.toISOString()}>
           {formatTime(now)}
-        </span>
+        </time>
       </div>
     </div>
   );


### PR DESCRIPTION
💡 What: Removed `aria-live="polite"` from clock components and replaced `<span>` with `<time dateTime="...">`.
🎯 Why: A ticking clock with `aria-live` interrupts screen readers every minute, causing a terrible UX.
♿ Accessibility: Vastly improves screen reader experience by stopping constant time updates and providing semantic time tags.

---
*PR created automatically by Jules for task [11726284761416211971](https://jules.google.com/task/11726284761416211971) started by @schmug*