### PR TITLE
⚡ Bolt: Deduplicate fetch requests in BlogApp

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -15,6 +15,10 @@ type BlogPayload = {
   fetchedAt: string;
 };
 
+// Module-level cache to prevent duplicate fetches when component unmounts and remounts
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
@@ -22,20 +26,33 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))));
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
💡 What: Implemented a module-level cache (`fetchPromise` and `cachedPayload`) in `BlogApp.tsx` to deduplicate and cache fetch requests for `/api/blog.json`. Added a `signal: AbortSignal.timeout(10000)` to prevent hangs.
🎯 Why: In the windowed OS architecture, components frequently mount and unmount when opened or closed. This wipes out local React state, causing redundant API requests for static/semi-static data.
📊 Impact: Eliminates redundant network requests when reopening the Blog app. Subsequent opens are instantaneous.
🔬 Measurement: Open the Blog app, close it, and open it again. Observe the Network tab in DevTools; there should be only one request to `/api/blog.json` per session.

---
*PR created automatically by Jules for task [6233829556345837338](https://jules.google.com/task/6233829556345837338) started by @schmug*