### PR TITLE
⚡ Bolt: Cache Blog API response to prevent redundant fetches

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -21,21 +21,38 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// Module-level cache to prevent duplicate fetches when multiple instances open/close
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))));
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
+        cachedPayload = data;
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
+        fetchPromise = null; // Allow retry on error
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
### 💡 What
Implemented a module-level cache for `BlogApp.tsx` and attached a timeout to its network fetch.

### 🎯 Why
In a windowed OS interface, components mount and unmount dynamically when their window opens or closes. By default, `BlogApp` destroyed its state upon closing and repeatedly performed network fetches to `/api/blog.json` every single time it was opened. This resulted in network waterfalls for essentially static data.

### 📊 Impact
* Eliminates duplicate API requests for `/api/blog.json` when opening/closing the app repeatedly.
* Instant data loading UI rendering for any open after the first.
* Protects against infinite hangs by bounding the fetch with a 10s AbortSignal timeout.
* Resolves overlapping concurrent network calls when multiple instances of the app open at exactly the same time.

### 🔬 Measurement
Load the application, open the Blog app (it will fetch). Close the Blog app, open it again (it will load instantly, verifiable in DevTools Network tab that no second request was made).

---
*PR created automatically by Jules for task [15184433077800664925](https://jules.google.com/task/15184433077800664925) started by @schmug*