### PR TITLE
🎨 Palette: Add accessible clear button to Projects filter input

### DIFF
--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { useProjects, relativeTime } from '../../../hooks/useProjects';
 
 export default function ProjectsApp() {
   const { payload, error } = useProjects();
   const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const filtered = useMemo(() => {
     if (!payload) return [];
@@ -35,6 +37,7 @@ export default function ProjectsApp() {
         <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
+            ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter by name, language, or description"
@@ -42,6 +45,19 @@ export default function ProjectsApp() {
             aria-label="Filter projects"
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              aria-label="Clear filter"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              className="rounded-sm text-[var(--color-muted)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} />
+            </button>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
This PR introduces a small UX and accessibility enhancement to the Projects app.

**What:** Added an explicit "Clear filter" button (using the standard `X` icon from `lucide-react`) to the search input in `ProjectsApp.tsx`.
**Why:** Previously, users had to manually backspace through their queries. A clear button improves navigation speed. More importantly, this implementation focuses heavily on accessibility: it uses an explicit `aria-label`, relies on `focus-visible` utility classes for distinct keyboard focus states, and programmatically restores focus back to the input field upon clearing the text.
**Accessibility:** Improved tab order, added screen-reader accessible label, and ensured focus is not lost when the search is cleared.

---
*PR created automatically by Jules for task [17559028696979327066](https://jules.google.com/task/17559028696979327066) started by @schmug*