### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to fetch requests

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: Add timeout to prevent DoS via hung network requests
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,8 +35,9 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      // Security: Add timeout to prevent DoS via hung network requests
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then(
+        (r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))),
       );
     }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: Add timeout to prevent DoS via hung network requests
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing timeout configurations on fetch calls across the application (both server-side and client-side).
🎯 **Impact:** Without explicit timeouts, fetch calls can hang indefinitely if the server or network is unresponsive. This can lead to resource exhaustion and potential Denial of Service (DoS), especially in server-rendered environments or during static builds.
🔧 **Fix:** Added `signal: AbortSignal.timeout(10000)` to the fetch calls in `src/lib/github.ts`, `src/components/os/apps/BlogApp.tsx`, and `src/hooks/useProjects.ts`. Added security comments.
✅ **Verification:** Verified by running lint, tests, typecheck, and build.

---
*PR created automatically by Jules for task [9535547210679571138](https://jules.google.com/task/9535547210679571138) started by @schmug*