### PR TITLE
🎨 Palette: Add accessible clear buttons to search inputs

### DIFF
--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { type AppManifest } from '../../apps/registry';
 import { renderIcon } from '../../apps/iconUtils';
 import { useAllApps } from '../../hooks/useAllApps';
@@ -88,6 +89,19 @@ export function Launcher({ open, onClose }: Props) {
             spellCheck={false}
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear search"
+              className="text-[var(--color-muted)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} />
+            </button>
+          )}
           <span className="font-mono text-[10px] text-[var(--color-muted)]">Esc</span>
         </div>
 

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { relativeTime } from '../../../hooks/useProjects';
 
 type BlogPost = {
@@ -25,6 +26,7 @@ export default function BlogApp() {
   const [payload, setPayload] = useState<BlogPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -71,6 +73,7 @@ export default function BlogApp() {
         <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
+            ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter by title, tag, or summary"
@@ -78,6 +81,19 @@ export default function BlogApp() {
             aria-label="Filter posts"
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear search"
+              className="text-[var(--color-muted)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} />
+            </button>
+          )}
         </div>
       </header>
 

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { useProjects, relativeTime } from '../../../hooks/useProjects';
 
 export default function ProjectsApp() {
   const { payload, error } = useProjects();
   const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const filtered = useMemo(() => {
     if (!payload) return [];
@@ -35,6 +37,7 @@ export default function ProjectsApp() {
         <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
+            ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter by name, language, or description"
@@ -42,6 +45,19 @@ export default function ProjectsApp() {
             aria-label="Filter projects"
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear search"
+              className="text-[var(--color-muted)] hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} />
+            </button>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
💡 **What**: Added an accessible 'clear' (`X`) button to the search and filter inputs across the application (Launcher, ProjectsApp, and BlogApp).

🎯 **Why**: When users are typing a long search query and want to start over, it's cumbersome to manually highlight and delete the text. Providing a clear button improves efficiency. Managing focus to return to the input upon clearing ensures continuous, accessible keyboard interaction.

📸 **Before/After**: 
The clear button appears only when there is input text. It uses the `lucide-react` `X` icon and aligns neatly inside the input container. 

♿ **Accessibility**: 
- Added `aria-label="Clear search"` for screen readers.
- Ensured keyboard accessibility with `focus-visible` ring styling.
- Restores focus to the search input element when clicked, allowing users to keep typing immediately.
- Added `type="button"` to ensure it doesn't accidentally trigger a form submission.

---
*PR created automatically by Jules for task [1057004159306697568](https://jules.google.com/task/1057004159306697568) started by @schmug*