### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeout to fetch calls to prevent DoS hangs

### DIFF
--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -28,7 +28,8 @@ export default function BlogApp() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
+    // Security: prevent application hangs via DoS by enforcing a timeout on fetch calls
+    fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,8 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
+      // Security: prevent application hangs via DoS by enforcing a timeout on fetch calls
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then((r) =>
         r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
       );
     }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: prevent application hangs via DoS by enforcing a timeout on external API calls
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing timeouts on external and internal network requests using `fetch`.
🎯 Impact: Applications can hang or experience Denial of Service (DoS) conditions if a server holds the connection open indefinitely without returning a response.
🔧 Fix: Wrapped fetch calls across `github.ts`, `useProjects.ts`, and `BlogApp.tsx` with `AbortSignal.timeout(10000)` to ensure failures occur gracefully and resources are released.
✅ Verification: Ran `pnpm test`, `pnpm lint`, and `pnpm build` to verify no regressions were introduced.

---
*PR created automatically by Jules for task [3813141656757748014](https://jules.google.com/task/3813141656757748014) started by @schmug*