### PR TITLE
feat: integrate BlogApp cache, fetch timeouts & a11y clear buttons (supersedes 27 PRs)

### DIFF
--- a/src/components/os/Launcher.tsx
+++ b/src/components/os/Launcher.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { type AppManifest } from '../../apps/registry';
 import { renderIcon } from '../../apps/iconUtils';
 import { useAllApps } from '../../hooks/useAllApps';
@@ -88,6 +89,19 @@ export function Launcher({ open, onClose }: Props) {
             spellCheck={false}
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear search"
+              className="text-[var(--color-muted)] transition hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
           <span className="font-mono text-[10px] text-[var(--color-muted)]">Esc</span>
         </div>
 

--- a/src/components/os/Taskbar.tsx
+++ b/src/components/os/Taskbar.tsx
@@ -104,9 +104,12 @@ export function Taskbar({ onOpenLauncher }: Props) {
         >
           /schmug
         </a>
-        <span className="font-mono text-xs text-[var(--color-dim)] tabular-nums" aria-live="polite">
+        <time
+          dateTime={now.toISOString()}
+          className="font-mono text-xs text-[var(--color-dim)] tabular-nums"
+        >
           {formatTime(now)}
-        </span>
+        </time>
       </div>
     </div>
   );

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { relativeTime } from '../../../hooks/useProjects';
 
 type BlogPost = {
@@ -21,21 +22,47 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// Module-level cache to prevent duplicate fetches when the component
+// unmounts and remounts (e.g., when the blog window is closed and reopened).
+let fetchPromise: Promise<BlogPayload> | null = null;
+let cachedPayload: BlogPayload | null = null;
+
 export default function BlogApp() {
-  const [payload, setPayload] = useState<BlogPayload | null>(null);
+  const [payload, setPayload] = useState<BlogPayload | null>(cachedPayload);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/blog.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      return;
+    }
+
+    if (!fetchPromise) {
+      // Security: timeout prevents DoS via hung network requests
+      fetchPromise = fetch('/api/blog.json', { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .then((data: BlogPayload) => {
+          cachedPayload = data;
+          return data;
+        })
+        .catch((err) => {
+          fetchPromise = null; // Allow retry on error
+          throw err;
+        });
+    }
+
+    fetchPromise
       .then((data: BlogPayload) => {
         if (!cancelled) setPayload(data);
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load');
       });
+
     return () => {
       cancelled = true;
     };
@@ -71,6 +98,7 @@ export default function BlogApp() {
         <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
+            ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter by title, tag, or summary"
@@ -78,6 +106,19 @@ export default function BlogApp() {
             aria-label="Filter posts"
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear filter"
+              className="text-[var(--color-muted)] transition hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
         </div>
       </header>
 

--- a/src/components/os/apps/ProjectsApp.tsx
+++ b/src/components/os/apps/ProjectsApp.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 import { useProjects, relativeTime } from '../../../hooks/useProjects';
 
 export default function ProjectsApp() {
   const { payload, error } = useProjects();
   const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const filtered = useMemo(() => {
     if (!payload) return [];
@@ -35,6 +37,7 @@ export default function ProjectsApp() {
         <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-shadow)] px-3 py-1.5 transition-shadow duration-200 focus-within:border-[var(--color-amber)] focus-within:ring-1 focus-within:ring-[var(--color-amber)]">
           <span className="font-mono text-[11px] text-[var(--color-amber)]">›</span>
           <input
+            ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter by name, language, or description"
@@ -42,6 +45,19 @@ export default function ProjectsApp() {
             aria-label="Filter projects"
             maxLength={100} // Security: prevent DoS via extremely long input strings
           />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear filter"
+              className="text-[var(--color-muted)] transition hover:text-[var(--color-amber)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-amber)]"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
         </div>
       </header>
 

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,8 +35,9 @@ export function useProjects() {
     }
 
     if (!fetchPromise) {
-      fetchPromise = fetch('/api/projects.json').then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
+      // Security: timeout prevents DoS via hung network requests
+      fetchPromise = fetch('/api/projects.json', { signal: AbortSignal.timeout(10000) }).then(
+        (r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))),
       );
     }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,7 +30,8 @@ export async function fetchAllRepos(username: string): Promise<Repo[]> {
   const token = process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { headers });
+  // Security: timeout prevents DoS via hung network requests
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
   if (!res.ok) {
     throw new Error(
       `GitHub API ${res.status} ${res.statusText} for ${url}` +


### PR DESCRIPTION
## What

Consolidates the three best PRs from the duplicate scheduled-agent backlog into one reviewed change, hand-resolving their overlapping edits to `BlogApp.tsx`.

| Source | Change |
|---|---|
| ⚡ #115 | BlogApp module-level fetch cache + 10s `AbortSignal.timeout` |
| 🛡️ #122 | Fetch timeouts on `useProjects.ts` + `github.ts` (redundant BlogApp hunk dropped — covered by #115's cache path) |
| 🎨 #114 | Accessible "clear" buttons on Launcher / Projects / Blog filter inputs + semantic `<time>` on desktop Taskbar clock |

## Why one PR instead of three merges

All three touched `BlogApp.tsx`, and #115 + #122 both added the *same* blog-fetch timeout — sequential merges would conflict and duplicate code. Triaged via parallel review agents; full analysis in the linked PRs.

## Behavior change (accepted)

The 10s timeout on the **build-time** `github.ts` fetch makes a transiently slow `api.github.com` fail the build fast instead of hanging. Deliberate hardening, accepted by the maintainer.

## Verification

- ✅ `format:check`, `lint`, `typecheck` (0 errors)
- ⚠️ Local `npm test` / `npm run build` could not be fully verified in the worktree sandbox (pre-existing `storage.setItem` vitest-env failure + no `api.github.com` network — **both reproduce identically on pristine `main`**, so zero regressions). **CI on this PR is the authoritative gate.**

## Supersedes / closes

**Winners folded in:** #115, #122, #114
**Duplicates closed:** Bolt #126 #120 #119 #113 #110 #108 #104 #101 #99 · Sentinel #125 #118 #111 #109 #105 #100 #97 · Palette #124 #121 #117 #116 #112 #107 #106 #102 #98 #96

Follow-up: mobile `StatusBar.tsx` clock still uses `<span aria-live>` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)