### PR TITLE
feat: scaffold /podcast section with R2-backed episodes + iTunes RSS

### DIFF
--- a/src/lib/__fixtures__/episodes.json
+++ b/src/lib/__fixtures__/episodes.json
@@ -1,0 +1,20 @@
+[
+  {
+    "slug": "2026-05-23-daily-digest",
+    "title": "Daily Digest — May 23, 2026",
+    "description": "Sample manifest entry. Used by tests and as a fallback shape reference.",
+    "pubDate": "2026-05-23T14:00:00Z",
+    "mp3_url": "https://audio.cortech.online/2026-05-23.mp3",
+    "mp3_bytes": 4192384,
+    "duration_s": 524.6,
+    "chapters": [
+      { "title": "Intro", "start_ms": 0, "source_url": null },
+      { "title": "Sample item one", "start_ms": 18000, "source_url": "https://example.com/one" },
+      { "title": "Sample item two", "start_ms": 122000, "source_url": "https://example.com/two" },
+      { "title": "Sign-off", "start_ms": 510000, "source_url": null }
+    ],
+    "spotify_uri": "spotify:episode:fixture",
+    "cover_url": null,
+    "explicit": false
+  }
+]

--- a/src/lib/episodes.ts
+++ b/src/lib/episodes.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+
+// The R2 manifest is the contract between clodcast (producer) and
+// cortech.online (consumer). Clodcast writes one JSON file per episode
+// under <bucket>/manifest.json and one mp3 under <bucket>/<slug>.mp3.
+// The manifest is a flat array of EpisodeEntry — the newest episodes
+// first, but the consumer sorts defensively anyway.
+
+const chapterSchema = z.object({
+  title: z.string(),
+  start_ms: z.number().int().nonnegative(),
+  source_url: z.url().nullable().optional(),
+});
+
+const episodeSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9-]+$/, 'slug must be lowercase kebab-case'),
+  title: z.string(),
+  description: z.string(),
+  pubDate: z.coerce.date(),
+  mp3_url: z.url(),
+  mp3_bytes: z.number().int().positive(),
+  duration_s: z.number().positive(),
+  chapters: z.array(chapterSchema).default([]),
+  spotify_uri: z.string().nullable().optional(),
+  cover_url: z.url().nullable().optional(),
+  explicit: z.boolean().default(false),
+});
+
+const manifestSchema = z.array(episodeSchema);
+
+export type Chapter = z.infer<typeof chapterSchema>;
+export type Episode = z.infer<typeof episodeSchema>;
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Resolve the manifest URL from env. Unset → graceful empty list, so this PR
+ * can ship before clodcast publishes anything. We treat unset / 404 / parse
+ * failure as "no episodes yet" rather than failing the build.
+ */
+function manifestUrl(): string | null {
+  const url = process.env.EPISODES_MANIFEST_URL;
+  return url && url.trim() ? url.trim() : null;
+}
+
+export async function fetchEpisodes(): Promise<Episode[]> {
+  const url = manifestUrl();
+  if (!url) return [];
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { 'User-Agent': 'cortech.online-portfolio', Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    console.warn(`[episodes] manifest fetch failed: ${(err as Error).message}`);
+    return [];
+  }
+
+  if (res.status === 404) return [];
+  if (!res.ok) {
+    console.warn(`[episodes] manifest ${url} returned ${res.status} ${res.statusText}`);
+    return [];
+  }
+
+  let raw: unknown;
+  try {
+    raw = await res.json();
+  } catch (err) {
+    console.warn(`[episodes] manifest parse failed: ${(err as Error).message}`);
+    return [];
+  }
+
+  const parsed = manifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    console.warn(`[episodes] manifest validation failed: ${parsed.error.message}`);
+    return [];
+  }
+
+  return parsed.data.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+}
+
+/**
+ * Format milliseconds as `H:MM:SS` (or `M:SS` under one hour) for chapter timestamps.
+ */
+export function formatChapterTimestamp(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const ss = String(seconds).padStart(2, '0');
+  if (hours > 0) {
+    const mm = String(minutes).padStart(2, '0');
+    return `${hours}:${mm}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+}

--- a/src/pages/_rss.xml.test.ts
+++ b/src/pages/_rss.xml.test.ts
@@ -18,8 +18,23 @@ type FakePost = {
   };
 };
 
+type FakeEpisode = {
+  slug: string;
+  title: string;
+  description: string;
+  pubDate: Date;
+  mp3_url: string;
+  mp3_bytes: number;
+  duration_s: number;
+  chapters: { title: string; start_ms: number; source_url?: string | null }[];
+  spotify_uri: string | null;
+  cover_url: string | null;
+  explicit: boolean;
+};
+
 const reposRef: { current: FakeRepo[] } = { current: [] };
 const postsRef: { current: FakePost[] } = { current: [] };
+const episodesRef: { current: FakeEpisode[] } = { current: [] };
 
 vi.mock('astro:content', () => ({
   // Mirror Astro's getCollection signature: optional filter that receives the entry.
@@ -29,6 +44,10 @@ vi.mock('astro:content', () => ({
 
 vi.mock('../lib/github', () => ({
   fetchOriginalRepos: async () => reposRef.current,
+}));
+
+vi.mock('../lib/episodes', () => ({
+  fetchEpisodes: async () => episodesRef.current,
 }));
 
 import { GET } from './rss.xml';
@@ -58,6 +77,7 @@ function listTitles(xml: string): string[] {
 beforeEach(() => {
   reposRef.current = [];
   postsRef.current = [];
+  episodesRef.current = [];
 });
 
 describe('rss.xml route', () => {
@@ -187,5 +207,49 @@ describe('rss.xml route', () => {
     const xml = await getXml();
     expect(xml).toContain('<category>blog</category>');
     expect(xml).toContain('<category>cortechos</category>');
+  });
+
+  it('includes podcast episodes in the unified feed sorted with posts and repos', async () => {
+    reposRef.current = [
+      {
+        name: 'older-repo',
+        description: 'old',
+        html_url: 'https://github.com/schmug/older-repo',
+        updated_at: '2026-04-01T00:00:00Z',
+      },
+    ];
+    postsRef.current = [
+      {
+        id: 'middle-post',
+        data: {
+          title: 'Middle Post',
+          description: 'in between',
+          pubDate: new Date('2026-04-10T00:00:00Z'),
+          tags: [],
+          draft: false,
+        },
+      },
+    ];
+    episodesRef.current = [
+      {
+        slug: 'newest-episode',
+        title: 'Newest Episode',
+        description: 'fresh',
+        pubDate: new Date('2026-04-20T00:00:00Z'),
+        mp3_url: 'https://audio.cortech.online/newest.mp3',
+        mp3_bytes: 1000,
+        duration_s: 100,
+        chapters: [],
+        spotify_uri: null,
+        cover_url: null,
+        explicit: false,
+      },
+    ];
+
+    const xml = await getXml();
+    expect(countItems(xml)).toBe(3);
+    expect(listTitles(xml)).toEqual(['Newest Episode', 'Middle Post', 'older-repo']);
+    expect(xml).toContain('https://cortech.online/podcast/newest-episode/');
+    expect(xml).toContain('<category>podcast</category>');
   });
 });

--- a/src/pages/podcast/[slug].astro
+++ b/src/pages/podcast/[slug].astro
@@ -1,0 +1,136 @@
+---
+import Base from '../../layouts/Base.astro';
+import { fetchEpisodes, formatChapterTimestamp, type Episode } from '../../lib/episodes';
+
+export async function getStaticPaths() {
+  const episodes = await fetchEpisodes();
+  return episodes.map((episode) => ({
+    params: { slug: episode.slug },
+    props: { episode },
+  }));
+}
+
+type Props = { episode: Episode };
+const { episode } = Astro.props;
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+const totalMs = Math.round(episode.duration_s * 1000);
+---
+
+<Base
+  title={episode.title}
+  description={episode.description}
+  canonical={`https://cortech.online/podcast/${episode.slug}`}
+>
+  <article class="mx-auto max-w-2xl px-6 pt-16 pb-16">
+    <a
+      href="/podcast"
+      class="font-mono text-[11px] tracking-[0.25em] text-[var(--color-muted)] uppercase transition hover:text-[var(--color-amber)]"
+    >
+      ← Podcast
+    </a>
+
+    <header class="mt-6">
+      <div
+        class="flex flex-wrap items-baseline gap-3 font-mono text-[10px] tracking-wider text-[var(--color-muted)] uppercase"
+      >
+        <time datetime={episode.pubDate.toISOString()}>
+          {dateFormatter.format(episode.pubDate)}
+        </time>
+        <span>{formatChapterTimestamp(totalMs)}</span>
+        <span>{episode.chapters.length} chapters</span>
+      </div>
+      <h1
+        class="mt-4 text-3xl font-[var(--font-display)] font-bold tracking-tight sm:text-4xl"
+      >
+        {episode.title}
+      </h1>
+      <p class="mt-3 text-base text-[var(--color-dim)]">{episode.description}</p>
+    </header>
+
+    <div class="mt-8">
+      <audio
+        id="episode-audio"
+        controls
+        preload="metadata"
+        src={episode.mp3_url}
+        class="w-full"
+      >
+        Your browser does not support the audio element.
+        <a href={episode.mp3_url} class="text-[var(--color-amber)] hover:underline">
+          Download the MP3
+        </a>.
+      </audio>
+    </div>
+
+    {
+      episode.chapters.length > 0 && (
+        <section class="mt-10">
+          <h2 class="font-mono text-[11px] tracking-[0.25em] text-[var(--color-amber)] uppercase">
+            Chapters
+          </h2>
+          <ol class="mt-4 divide-y divide-[var(--color-border)]">
+            {episode.chapters.map((chapter) => (
+              <li class="flex items-baseline gap-4 py-3">
+                <button
+                  type="button"
+                  data-start-ms={chapter.start_ms}
+                  class="chapter-jump shrink-0 font-mono text-xs tabular-nums text-[var(--color-muted)] transition hover:text-[var(--color-amber)]"
+                  aria-label={`Jump to ${chapter.title}`}
+                >
+                  {formatChapterTimestamp(chapter.start_ms)}
+                </button>
+                <div class="min-w-0 flex-1">
+                  <p class="text-sm text-[var(--color-text)]">{chapter.title}</p>
+                  {chapter.source_url && (
+                    <a
+                      href={chapter.source_url}
+                      rel="noopener"
+                      class="mt-0.5 inline-block truncate text-xs text-[var(--color-dim)] hover:text-[var(--color-amber)]"
+                    >
+                      {chapter.source_url}
+                    </a>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )
+    }
+
+    {
+      episode.spotify_uri && (
+        <p class="mt-10 text-xs text-[var(--color-muted)]">
+          Also on Spotify:{' '}
+          <a
+            href={`https://open.spotify.com/episode/${episode.spotify_uri.replace('spotify:episode:', '')}`}
+            rel="noopener"
+            class="text-[var(--color-amber)] hover:underline"
+          >
+            {episode.spotify_uri}
+          </a>
+        </p>
+      )
+    }
+  </article>
+
+  <script>
+    document.querySelectorAll<HTMLButtonElement>('.chapter-jump').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const audio = document.getElementById('episode-audio') as HTMLAudioElement | null;
+        if (!audio) return;
+        const ms = Number(btn.dataset.startMs ?? 0);
+        audio.currentTime = ms / 1000;
+        audio.play().catch(() => {
+          // Autoplay can be blocked; the seek still happened, that's the important part.
+        });
+      });
+    });
+  </script>
+</Base>

--- a/src/pages/podcast/[slug].astro
+++ b/src/pages/podcast/[slug].astro
@@ -45,22 +45,14 @@ const totalMs = Math.round(episode.duration_s * 1000);
         <span>{formatChapterTimestamp(totalMs)}</span>
         <span>{episode.chapters.length} chapters</span>
       </div>
-      <h1
-        class="mt-4 text-3xl font-[var(--font-display)] font-bold tracking-tight sm:text-4xl"
-      >
+      <h1 class="mt-4 text-3xl font-[var(--font-display)] font-bold tracking-tight sm:text-4xl">
         {episode.title}
       </h1>
       <p class="mt-3 text-base text-[var(--color-dim)]">{episode.description}</p>
     </header>
 
     <div class="mt-8">
-      <audio
-        id="episode-audio"
-        controls
-        preload="metadata"
-        src={episode.mp3_url}
-        class="w-full"
-      >
+      <audio id="episode-audio" controls preload="metadata" src={episode.mp3_url} class="w-full">
         Your browser does not support the audio element.
         <a href={episode.mp3_url} class="text-[var(--color-amber)] hover:underline">
           Download the MP3
@@ -80,7 +72,7 @@ const totalMs = Math.round(episode.duration_s * 1000);
                 <button
                   type="button"
                   data-start-ms={chapter.start_ms}
-                  class="chapter-jump shrink-0 font-mono text-xs tabular-nums text-[var(--color-muted)] transition hover:text-[var(--color-amber)]"
+                  class="chapter-jump shrink-0 font-mono text-xs text-[var(--color-muted)] tabular-nums transition hover:text-[var(--color-amber)]"
                   aria-label={`Jump to ${chapter.title}`}
                 >
                   {formatChapterTimestamp(chapter.start_ms)}

--- a/src/pages/podcast/_rss.xml.test.ts
+++ b/src/pages/podcast/_rss.xml.test.ts
@@ -59,6 +59,17 @@ describe('podcast rss.xml route', () => {
     expect(countItems(xml)).toBe(0);
   });
 
+  it('declares an atom:link rel="self" pointing at the feed URL', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('xmlns:atom="http://www.w3.org/2005/Atom"');
+    // The serializer in @astrojs/rss may emit the self-closing tag with or
+    // without a space before "/>", so match by structural pieces rather than
+    // the exact whitespace.
+    expect(xml).toMatch(
+      /<atom:link href="https:\/\/cortech\.online\/podcast\/rss\.xml" rel="self" type="application\/rss\+xml"\s*\/>/,
+    );
+  });
+
   it('declares required channel-level iTunes tags', async () => {
     const xml = await getXml();
     expect(xml).toContain('<itunes:author>');

--- a/src/pages/podcast/_rss.xml.test.ts
+++ b/src/pages/podcast/_rss.xml.test.ts
@@ -4,9 +4,7 @@ import type { Episode } from '../../lib/episodes';
 const episodesRef: { current: Episode[] } = { current: [] };
 
 vi.mock('../../lib/episodes', async () => {
-  const actual = await vi.importActual<typeof import('../../lib/episodes')>(
-    '../../lib/episodes',
-  );
+  const actual = await vi.importActual<typeof import('../../lib/episodes')>('../../lib/episodes');
   return {
     ...actual,
     fetchEpisodes: async () => episodesRef.current,

--- a/src/pages/podcast/_rss.xml.test.ts
+++ b/src/pages/podcast/_rss.xml.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Episode } from '../../lib/episodes';
+
+const episodesRef: { current: Episode[] } = { current: [] };
+
+vi.mock('../../lib/episodes', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/episodes')>(
+    '../../lib/episodes',
+  );
+  return {
+    ...actual,
+    fetchEpisodes: async () => episodesRef.current,
+  };
+});
+
+import { GET } from './rss.xml';
+
+const SITE = new URL('https://cortech.online');
+
+function makeContext() {
+  return { site: SITE } as Parameters<typeof GET>[0];
+}
+
+async function getXml(): Promise<string> {
+  const res = await GET(makeContext());
+  return await res.text();
+}
+
+function countItems(xml: string): number {
+  return xml.match(/<item>/g)?.length ?? 0;
+}
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+  return {
+    slug: 'sample-episode',
+    title: 'Sample Episode',
+    description: 'desc',
+    pubDate: new Date('2026-05-20T12:00:00Z'),
+    mp3_url: 'https://audio.cortech.online/sample.mp3',
+    mp3_bytes: 1000000,
+    duration_s: 300,
+    chapters: [],
+    spotify_uri: null,
+    cover_url: null,
+    explicit: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  episodesRef.current = [];
+});
+
+describe('podcast rss.xml route', () => {
+  it('returns a valid empty feed when no episodes exist', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<rss');
+    expect(xml).toContain('xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"');
+    expect(countItems(xml)).toBe(0);
+  });
+
+  it('declares required channel-level iTunes tags', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<itunes:author>');
+    expect(xml).toContain('<itunes:explicit>false</itunes:explicit>');
+    expect(xml).toContain('<itunes:type>episodic</itunes:type>');
+    expect(xml).toContain('<itunes:image href=');
+    expect(xml).toContain('<itunes:category text=');
+    expect(xml).toContain('<itunes:owner>');
+  });
+
+  it('emits an <enclosure> with byte length and audio/mpeg type', async () => {
+    episodesRef.current = [
+      makeEpisode({
+        mp3_url: 'https://audio.cortech.online/abc.mp3',
+        mp3_bytes: 4192384,
+      }),
+    ];
+
+    const xml = await getXml();
+    expect(xml).toContain('url="https://audio.cortech.online/abc.mp3"');
+    expect(xml).toContain('length="4192384"');
+    expect(xml).toContain('type="audio/mpeg"');
+  });
+
+  it('emits item-level <itunes:duration> in whole seconds', async () => {
+    episodesRef.current = [makeEpisode({ duration_s: 524.6 })];
+    const xml = await getXml();
+    expect(xml).toContain('<itunes:duration>525</itunes:duration>');
+  });
+
+  it('numbers episodes so newest gets the highest itunes:episode', async () => {
+    episodesRef.current = [
+      makeEpisode({ slug: 'newer', pubDate: new Date('2026-05-21') }),
+      makeEpisode({ slug: 'older', pubDate: new Date('2026-05-20') }),
+    ];
+    const xml = await getXml();
+    // newest first → episode 2; older → episode 1
+    const items = xml.split('<item>').slice(1);
+    expect(items[0]).toContain('<itunes:episode>2</itunes:episode>');
+    expect(items[1]).toContain('<itunes:episode>1</itunes:episode>');
+  });
+
+  it('uses /podcast/<slug>/ absolute links scoped to context.site', async () => {
+    episodesRef.current = [makeEpisode({ slug: 'foo-bar' })];
+    const xml = await getXml();
+    expect(xml).toContain('https://cortech.online/podcast/foo-bar/');
+  });
+
+  it('marks explicit episodes per-item', async () => {
+    episodesRef.current = [makeEpisode({ explicit: true })];
+    const xml = await getXml();
+    const itemBlock = xml.split('<item>')[1] ?? '';
+    expect(itemBlock).toContain('<itunes:explicit>true</itunes:explicit>');
+  });
+});

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -26,16 +26,16 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
       </h1>
       <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
         AI-narrated daily walk through the links in my morning queue. Subscribe via the
-        <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a>.
-        Individual episodes also publish to Spotify — see the per-episode page for the link.
+        <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a
+        >. Individual episodes also publish to Spotify — see the per-episode page for the link.
       </p>
     </div>
 
     {
       episodes.length === 0 ? (
         <p class="mt-12 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-6 text-sm text-[var(--color-muted)]">
-          No episodes published yet — the manifest at <code>EPISODES_MANIFEST_URL</code> is
-          empty or unset. Check back soon.
+          No episodes published yet — the manifest at <code>EPISODES_MANIFEST_URL</code> is empty or
+          unset. Check back soon.
         </p>
       ) : (
         <ul class="mt-10 divide-y divide-[var(--color-border)]">

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -26,15 +26,8 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
       </h1>
       <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
         AI-narrated daily walk through the links in my morning queue. Subscribe via the
-        <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a>
-        or listen on
-        <a
-          href="https://open.spotify.com/show/"
-          rel="noopener"
-          class="text-[var(--color-amber)] hover:underline"
-        >
-          Spotify
-        </a>.
+        <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a>.
+        Individual episodes also publish to Spotify — see the per-episode page for the link.
       </p>
     </div>
 

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -1,0 +1,73 @@
+---
+import Base from '../../layouts/Base.astro';
+import { fetchEpisodes, formatChapterTimestamp } from '../../lib/episodes';
+
+const episodes = await fetchEpisodes();
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<Base
+  title="Podcast"
+  description="Daily Digest — a daily AI-narrated digest of links worth your morning. By Cory Schmug."
+  canonical="https://cortech.online/podcast"
+>
+  <section class="mx-auto max-w-2xl px-6 pt-16 pb-10">
+    <div>
+      <p class="font-mono text-[11px] tracking-[0.35em] text-[var(--color-amber)] uppercase">
+        Podcast
+      </p>
+      <h1 class="mt-2 text-3xl font-[var(--font-display)] font-bold tracking-tight sm:text-4xl">
+        Daily Digest
+      </h1>
+      <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
+        AI-narrated daily walk through the links in my morning queue. Subscribe via the
+        <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a>
+        or listen on
+        <a
+          href="https://open.spotify.com/show/"
+          rel="noopener"
+          class="text-[var(--color-amber)] hover:underline"
+        >
+          Spotify
+        </a>.
+      </p>
+    </div>
+
+    {
+      episodes.length === 0 ? (
+        <p class="mt-12 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)]/60 p-6 text-sm text-[var(--color-muted)]">
+          No episodes published yet — the manifest at <code>EPISODES_MANIFEST_URL</code> is
+          empty or unset. Check back soon.
+        </p>
+      ) : (
+        <ul class="mt-10 divide-y divide-[var(--color-border)]">
+          {episodes.map((ep) => (
+            <li class="py-5">
+              <a
+                href={`/podcast/${ep.slug}/`}
+                class="group block transition hover:text-[var(--color-amber)]"
+              >
+                <div class="flex items-baseline gap-3 font-mono text-[10px] tracking-wider text-[var(--color-muted)] uppercase">
+                  <time datetime={ep.pubDate.toISOString()}>
+                    {dateFormatter.format(ep.pubDate)}
+                  </time>
+                  <span>{formatChapterTimestamp(Math.round(ep.duration_s * 1000))}</span>
+                  <span>{ep.chapters.length} chapters</span>
+                </div>
+                <h2 class="mt-1 text-xl font-[var(--font-display)] font-semibold text-[var(--color-text)] group-hover:text-[var(--color-amber)]">
+                  {ep.title}
+                </h2>
+                <p class="mt-1 text-sm text-[var(--color-dim)]">{ep.description}</p>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </section>
+</Base>

--- a/src/pages/podcast/rss.xml.ts
+++ b/src/pages/podcast/rss.xml.ts
@@ -1,0 +1,82 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { fetchEpisodes } from '../../lib/episodes';
+
+// Apple Podcasts directory requires the iTunes namespace + a fairly strict
+// set of channel-level tags. Item-level adds <enclosure> (the audio binary)
+// and <itunes:duration>. The bytes-accurate `length` on <enclosure> is
+// load-bearing for some podcatchers; clodcast supplies it from ffprobe.
+
+const PODCAST_TITLE = 'Daily Digest — Cortech';
+const PODCAST_DESCRIPTION =
+  'A daily, AI-narrated digest of links worth your morning — AI tooling, security, Cloudflare, and developer ergonomics. Produced by Cory Schmug.';
+const AUTHOR = 'Cory Schmug';
+const OWNER_NAME = 'Cory Schmug';
+const OWNER_EMAIL = 'cory@cortech.online';
+const CATEGORY = 'Technology';
+const COVER_URL = 'https://cortech.online/og-image.png';
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET(context: APIContext) {
+  const episodes = await fetchEpisodes();
+  const site = context.site!;
+
+  const channelExtras = [
+    `<language>en-us</language>`,
+    `<itunes:author>${escapeXml(AUTHOR)}</itunes:author>`,
+    `<itunes:summary>${escapeXml(PODCAST_DESCRIPTION)}</itunes:summary>`,
+    `<itunes:explicit>false</itunes:explicit>`,
+    `<itunes:type>episodic</itunes:type>`,
+    `<itunes:image href="${escapeXml(COVER_URL)}" />`,
+    `<itunes:category text="${escapeXml(CATEGORY)}" />`,
+    `<itunes:owner><itunes:name>${escapeXml(OWNER_NAME)}</itunes:name><itunes:email>${escapeXml(OWNER_EMAIL)}</itunes:email></itunes:owner>`,
+  ].join('');
+
+  const totalEpisodes = episodes.length;
+
+  return rss({
+    title: PODCAST_TITLE,
+    description: PODCAST_DESCRIPTION,
+    site,
+    xmlns: { itunes: 'http://www.itunes.com/dtds/podcast-1.0.dtd' },
+    customData: channelExtras,
+    items: episodes.map((ep, idx) => {
+      const episodeNumber = totalEpisodes - idx; // newest is highest
+      const durationSeconds = Math.round(ep.duration_s);
+      const itemExtras = [
+        `<itunes:author>${escapeXml(AUTHOR)}</itunes:author>`,
+        `<itunes:duration>${durationSeconds}</itunes:duration>`,
+        `<itunes:episode>${episodeNumber}</itunes:episode>`,
+        `<itunes:explicit>${ep.explicit ? 'true' : 'false'}</itunes:explicit>`,
+        ep.cover_url
+          ? `<itunes:image href="${escapeXml(ep.cover_url)}" />`
+          : '',
+      ]
+        .filter(Boolean)
+        .join('');
+
+      return {
+        title: ep.title,
+        description: ep.description,
+        link: new URL(`/podcast/${ep.slug}/`, site).toString(),
+        pubDate: ep.pubDate,
+        enclosure: {
+          url: ep.mp3_url,
+          length: ep.mp3_bytes,
+          type: 'audio/mpeg',
+        },
+        customData: itemExtras,
+      };
+    }),
+  });
+}
+
+export const prerender = true;

--- a/src/pages/podcast/rss.xml.ts
+++ b/src/pages/podcast/rss.xml.ts
@@ -28,8 +28,10 @@ function escapeXml(s: string): string {
 export async function GET(context: APIContext) {
   const episodes = await fetchEpisodes();
   const site = context.site!;
+  const feedSelfUrl = new URL('/podcast/rss.xml', site).toString();
 
   const channelExtras = [
+    `<atom:link href="${escapeXml(feedSelfUrl)}" rel="self" type="application/rss+xml" />`,
     `<language>en-us</language>`,
     `<itunes:author>${escapeXml(AUTHOR)}</itunes:author>`,
     `<itunes:summary>${escapeXml(PODCAST_DESCRIPTION)}</itunes:summary>`,
@@ -46,7 +48,10 @@ export async function GET(context: APIContext) {
     title: PODCAST_TITLE,
     description: PODCAST_DESCRIPTION,
     site,
-    xmlns: { itunes: 'http://www.itunes.com/dtds/podcast-1.0.dtd' },
+    xmlns: {
+      itunes: 'http://www.itunes.com/dtds/podcast-1.0.dtd',
+      atom: 'http://www.w3.org/2005/Atom',
+    },
     customData: channelExtras,
     items: episodes.map((ep, idx) => {
       const episodeNumber = totalEpisodes - idx; // newest is highest

--- a/src/pages/podcast/rss.xml.ts
+++ b/src/pages/podcast/rss.xml.ts
@@ -61,9 +61,7 @@ export async function GET(context: APIContext) {
         `<itunes:duration>${durationSeconds}</itunes:duration>`,
         `<itunes:episode>${episodeNumber}</itunes:episode>`,
         `<itunes:explicit>${ep.explicit ? 'true' : 'false'}</itunes:explicit>`,
-        ep.cover_url
-          ? `<itunes:image href="${escapeXml(ep.cover_url)}" />`
-          : '',
+        ep.cover_url ? `<itunes:image href="${escapeXml(ep.cover_url)}" />` : '',
       ]
         .filter(Boolean)
         .join('');

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,11 +2,13 @@ import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 import { fetchOriginalRepos } from '../lib/github';
+import { fetchEpisodes } from '../lib/episodes';
 
 export async function GET(context: APIContext) {
-  const [repos, posts] = await Promise.all([
+  const [repos, posts, episodes] = await Promise.all([
     fetchOriginalRepos('schmug'),
     getCollection('blog', ({ data }) => !data.draft),
+    fetchEpisodes(),
   ]);
 
   const repoItems = repos.map((r) => ({
@@ -25,7 +27,15 @@ export async function GET(context: APIContext) {
     categories: ['blog', ...p.data.tags],
   }));
 
-  const items = [...repoItems, ...postItems]
+  const episodeItems = episodes.map((ep) => ({
+    title: ep.title,
+    description: ep.description,
+    link: new URL(`/podcast/${ep.slug}/`, context.site!).toString(),
+    pubDate: ep.pubDate,
+    categories: ['podcast'],
+  }));
+
+  const items = [...repoItems, ...postItems, ...episodeItems]
     .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
     .slice(0, 40);
 


### PR DESCRIPTION
## Summary

Consumer side of the daily-digest podcast pipeline. The producer (clodcast) will write `<bucket>/<slug>.mp3` and a `<bucket>/manifest.json` to R2 after each successful Spotify upload; this PR makes cortech.online read that manifest at build time and surface episodes on the site + in feeds.

New routes:

- **`/podcast/`** — listing page with a graceful empty state until the manifest is populated.
- **`/podcast/[slug]/`** — episode page with an `<audio>` player and a chapter list whose timestamps click-to-scrub the player.
- **`/podcast/rss.xml`** — full iTunes-namespaced podcast feed: `<enclosure url length type>`, `itunes:duration`, `itunes:episode`, channel-level `itunes:author/owner/category/image/explicit/type`, plus `<atom:link rel="self">` so feed validators don't complain.

The existing **`/rss.xml`** (the unified blog/repos feed) is extended to also include episodes, so anyone subscribed to the blog feed automatically gets new episodes.

## Why this shape (and what's not in this PR)

The design we settled on in conversation: clodcast and cortech.online don't touch each other's filesystems or git history. R2 is the integration surface — clodcast publishes mp3 + sidecar JSON, cortech.online reads the manifest at build time. That keeps the portfolio repo lean (no audio in git), avoids a distributed transaction across two repos, and lets each side evolve independently.

- The episode contract is the **Zod schema in [src/lib/episodes.ts](src/lib/episodes.ts)**. That's the document clodcast will write against.
- **`fetchEpisodes()` returns `[]` (not throws)** when `EPISODES_MANIFEST_URL` is unset, returns 404, or yields malformed JSON. This is deliberate so the PR can ship and deploy before clodcast publishes anything; once the env var is set on Pages, episodes appear on the next build.

Out of scope on purpose (separate follow-ups):
- Nav/launcher additions on the homepage, mobile shell integration, the desktop Blog app surfacing episodes.
- Any clodcast-side `render.py` changes (R2 PUT, manifest update, Pages deploy-hook ping).
- The channel cover at `og-image.png` is 1200×630, which is fine for Overcast/Pocket Casts/Castro but **below Apple Podcasts' 1400×1400-square minimum**. If the goal extends to Apple Podcasts directory submission, a square cover needs to be added — flagging here rather than papering over it.

## Test plan

- [x] `npm test` — 12 files, 98 tests passing locally (vitest)
- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm run build` with `EPISODES_MANIFEST_URL` **unset** — succeeds; emits `/podcast/index.html` and `/podcast/rss.xml` (with empty `<channel>`, all required iTunes tags, and `<atom:link rel="self">`)
- [ ] Manually point `EPISODES_MANIFEST_URL` at the fixture (`src/lib/__fixtures__/episodes.json` served over HTTP) and confirm `/podcast/[slug]/` renders + chapter-jump scrubs the audio
- [ ] After merge: set `EPISODES_MANIFEST_URL` on the Cloudflare Pages env, point clodcast at the same R2 bucket, run a real daily and confirm a new episode appears on the next deploy
- [ ] Run the rendered `/podcast/rss.xml` through cast.feed-validator.com once a real episode is in it

🤖 Generated with [Claude Code](https://claude.com/claude-code)