### PR TITLE
fix(podcast): rebrand RSS feed to "Cortech — Daily Digest Podcast" / "Schmug"

### DIFF
--- a/src/pages/podcast/_rss.xml.test.ts
+++ b/src/pages/podcast/_rss.xml.test.ts
@@ -78,6 +78,24 @@ describe('podcast rss.xml route', () => {
     expect(xml).toContain('<itunes:owner>');
   });
 
+  it('titles the channel "Cortech — Daily Digest Podcast" with the em dash', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('Cortech — Daily Digest Podcast');
+  });
+
+  it('credits "Schmug" as the channel and item author', async () => {
+    episodesRef.current = [makeEpisode()];
+    const xml = await getXml();
+    // channel + item level both render the constant
+    const authorTags = xml.match(/<itunes:author>Schmug<\/itunes:author>/g) ?? [];
+    expect(authorTags.length).toBe(2);
+  });
+
+  it('names "Schmug" as the iTunes owner contact', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<itunes:name>Schmug</itunes:name>');
+  });
+
   it('emits an <enclosure> with byte length and audio/mpeg type', async () => {
     episodesRef.current = [
       makeEpisode({

--- a/src/pages/podcast/rss.xml.ts
+++ b/src/pages/podcast/rss.xml.ts
@@ -7,11 +7,11 @@ import { fetchEpisodes } from '../../lib/episodes';
 // and <itunes:duration>. The bytes-accurate `length` on <enclosure> is
 // load-bearing for some podcatchers; clodcast supplies it from ffprobe.
 
-const PODCAST_TITLE = 'Daily Digest — Cortech';
+const PODCAST_TITLE = 'Cortech — Daily Digest Podcast';
 const PODCAST_DESCRIPTION =
   'A daily, AI-narrated digest of links worth your morning — AI tooling, security, Cloudflare, and developer ergonomics. Produced by Cory Schmug.';
-const AUTHOR = 'Cory Schmug';
-const OWNER_NAME = 'Cory Schmug';
+const AUTHOR = 'Schmug';
+const OWNER_NAME = 'Schmug';
 const OWNER_EMAIL = 'cory@cortech.online';
 const CATEGORY = 'Technology';
 // Apple Podcasts & Spotify require square cover art, 1400–3000px. og-image.png


### PR DESCRIPTION
## Summary

Cosmetic/branding correction to the podcast RSS feed (`src/pages/podcast/rss.xml.ts`), per #141:

- Channel `<title>`: `Daily Digest — Cortech` → **`Cortech — Daily Digest Podcast`** (em dash preserved exactly).
- `<itunes:author>` (channel + item level): `Cory Schmug` → **`Schmug`**.
- `<itunes:owner><itunes:name>` (`OWNER_NAME`): `Cory Schmug` → **`Schmug`** — resolving the issue's open question with the stated default, matching the author and the repo convention that the site owner is referred to as *Schmug*.

`OWNER_EMAIL` and the channel description/summary copy (`PODCAST_DESCRIPTION`, which still reads "Produced by Cory Schmug") are intentionally untouched — out of scope per the issue.

Adds `_rss.xml.test.ts` assertions for the new title, the author string (channel + item → 2 `<itunes:author>Schmug</itunes:author>` tags), and the owner name.

Verified against the actual `npm run build` output (route is `prerender = true`):

```xml
<title>Cortech — Daily Digest Podcast</title>
...
<itunes:author>Schmug</itunes:author>
...
<itunes:owner><itunes:name>Schmug</itunes:name><itunes:email>cory@cortech.online</itunes:email></itunes:owner>
```

## Test plan

- [x] Unit tests pass (`npm test` — 142 passed)
- [x] Prettier + ESLint clean
- [x] TypeScript checks pass (`npm run typecheck` — 0 errors)
- [x] Build succeeds and generated `dist/podcast/rss.xml` shows corrected branding
- [ ] Verified at https://cortech.online/podcast/rss.xml after deploy

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)