### PR TITLE
fix(rss): stop listing podcast episodes in /rss.xml to end cross-feed duplication

### DIFF
--- a/src/pages/_rss.xml.test.ts
+++ b/src/pages/_rss.xml.test.ts
@@ -218,21 +218,25 @@ describe('rss.xml route', () => {
     expect(xml).toContain('<category>cortechos</category>');
   });
 
-  it('includes podcast episodes in the unified feed sorted with posts and repos', async () => {
+  it('excludes podcast episodes — they live only in /podcast/rss.xml (#149)', async () => {
+    // Episodes are intentionally absent from the everything-feed: the dedicated
+    // podcast feed carries them with audio enclosures, and listing them here too
+    // duplicated every episode for anyone subscribed to both feeds. This guard
+    // fails if episodes are ever merged back into /rss.xml.
     reposRef.current = [
       {
-        name: 'older-repo',
-        description: 'old',
-        html_url: 'https://github.com/schmug/older-repo',
+        name: 'a-repo',
+        description: 'repo',
+        html_url: 'https://github.com/schmug/a-repo',
         updated_at: '2026-04-01T00:00:00Z',
       },
     ];
     postsRef.current = [
       {
-        id: 'middle-post',
+        id: 'a-post',
         data: {
-          title: 'Middle Post',
-          description: 'in between',
+          title: 'A Post',
+          description: 'post',
           pubDate: new Date('2026-04-10T00:00:00Z'),
           tags: [],
           draft: false,
@@ -256,41 +260,11 @@ describe('rss.xml route', () => {
     ];
 
     const xml = await getXml();
-    expect(countItems(xml)).toBe(3);
-    expect(listTitles(xml)).toEqual(['Newest Episode', 'Middle Post', 'older-repo']);
-    expect(xml).toContain('https://cortech.online/podcast/newest-episode/');
-    expect(xml).toContain('<category>podcast</category>');
-  });
-
-  it('reduces a Spotify-flavored episode description to a clean summary blurb', async () => {
-    // The everything-feed is a general aggregator (no enclosures) where repos
-    // and posts carry short plain-text blurbs. An episode entry should match —
-    // the lead summary, not the full HTML chapter list the dedicated podcast
-    // feed keeps as show notes.
-    episodesRef.current = [
-      {
-        slug: 'episode-with-chapters',
-        title: 'Episode With Chapters',
-        description:
-          '<p>The clean lead summary.</p><p>(0:00) - Intro</p>' +
-          '<p>(1:23) - Topic - <a href="https://example.com/story">source</a></p>',
-        pubDate: new Date('2026-04-20T00:00:00Z'),
-        mp3_url: 'https://audio.cortech.online/ep.mp3',
-        mp3_bytes: 1000,
-        duration_s: 100,
-        chapters: [],
-        spotify_uri: null,
-        cover_url: null,
-        explicit: false,
-      },
-    ];
-
-    const xml = await getXml();
-    const itemBlock = xml.split('<item>').find((b) => b.includes('episode-with-chapters')) ?? '';
-    expect(itemBlock).toContain('The clean lead summary.');
-    expect(itemBlock).not.toContain('(0:00)');
-    expect(itemBlock).not.toContain('(1:23)');
-    expect(itemBlock).not.toContain('example.com');
-    expect(itemBlock).not.toContain('&lt;p&gt;');
+    // Only repo + post items; the episode must not appear despite being newest.
+    expect(countItems(xml)).toBe(2);
+    expect(listTitles(xml)).toEqual(['A Post', 'a-repo']);
+    expect(xml).not.toContain('Newest Episode');
+    expect(xml).not.toContain('newest-episode');
+    expect(xml).not.toContain('<category>podcast</category>');
   });
 });

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,13 +2,11 @@ import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 import { fetchOriginalRepos } from '../lib/github';
-import { fetchEpisodes, summaryText } from '../lib/episodes';
 
 export async function GET(context: APIContext) {
-  const [repos, posts, episodes] = await Promise.all([
+  const [repos, posts] = await Promise.all([
     fetchOriginalRepos('schmug'),
     getCollection('blog', ({ data }) => !data.draft),
-    fetchEpisodes(),
   ]);
 
   const repoItems = repos.map((r) => ({
@@ -27,18 +25,10 @@ export async function GET(context: APIContext) {
     categories: ['blog', ...p.data.tags],
   }));
 
-  const episodeItems = episodes.map((ep) => ({
-    title: ep.title,
-    // ep.description is Spotify-flavored HTML (lead summary + a <p> per chapter).
-    // This general feed carries short plain-text blurbs like the repo/post items,
-    // so use the lead summary; full show notes live in /podcast/rss.xml.
-    description: summaryText(ep.description),
-    link: new URL(`/podcast/${ep.slug}/`, context.site!).toString(),
-    pubDate: ep.pubDate,
-    categories: ['podcast'],
-  }));
-
-  const items = [...repoItems, ...postItems, ...episodeItems]
+  // Podcast episodes are intentionally NOT listed here. They live only in
+  // /podcast/rss.xml (with audio enclosures); listing them in both feeds
+  // duplicated every episode for anyone subscribed to both (#149).
+  const items = [...repoItems, ...postItems]
     .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
     .slice(0, 40);
 


### PR DESCRIPTION
## Problem

Each Daily Digest episode appeared **twice** for anyone subscribed to both feeds:

- `/rss.xml` — a plain-text teaser (no audio), `<category>podcast</category>`
- `/podcast/rss.xml` — the real playable copy with an audio `<enclosure>` + iTunes tags

RSS readers can't dedupe across separate feeds, so dual-subscribers saw both copies of every episode. Closes #149.

## Decision

There's no way to *both* tease episodes in the main feed *and* avoid duplication for dual-subscribers — the feeds overlap and RSS has no cross-feed dedup. Per product call, episodes are removed from `/rss.xml` and live only in the dedicated podcast feed. Trade-off: main-feed-only followers no longer get new-episode teasers (they can subscribe to `/podcast/rss.xml`).

## Changes

- `src/pages/rss.xml.ts`: drop `episodeItems` and the `fetchEpisodes`/`summaryText` imports; merged `items` is now `[...repoItems, ...postItems]`. Repo + blog items and `prerender = true` unchanged.
- `src/pages/_rss.xml.test.ts`: the two episode-inclusion tests are replaced by one inverted **regression guard** — it seeds an episode via the existing mock and asserts it does *not* appear, so re-introducing episodes into `/rss.xml` fails the test.
- `/podcast/rss.xml` and the clodcast audio pipeline are **untouched**.

## Verification (local, mirrors CI)

- `format:check` ✅ · `lint` ✅ (0 errors) · `typecheck` ✅ (0 errors)
- `npm test` ✅ **150 passed (21 files)**
- `npm run build` ✅ — built `dist/rss.xml` has **0** episode items / `podcast` categories / enclosures; `dist/podcast/rss.xml` retains its iTunes namespace
- `npm run test:e2e`: 9 passed, 1 failed — the failure (`iframe embed › all iframe apps … dmarc.mx`) is a **sandbox-network** issue (external site unreachable); confirmed identical on the clean baseline via stash-and-rerun, so it is **not** introduced by this change. It passes in CI, which has network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)