### PR TITLE
fix(podcast): wrap long chapter source URLs instead of overflowing the page

### DIFF
--- a/e2e/fixtures/podcast-manifest.json
+++ b/e2e/fixtures/podcast-manifest.json
@@ -1,0 +1,27 @@
+[
+  {
+    "slug": "e2e-fixture-episode",
+    "title": "E2E Fixture Episode",
+    "description": "<p>A fixture episode built for the Playwright suite. Its chapters carry deliberately long source URLs so the layout is exercised at mobile widths.</p>",
+    "pubDate": "2026-01-02T10:00:00.000Z",
+    "mp3_url": "https://example.com/e2e-fixture-episode.mp3",
+    "mp3_bytes": 1234567,
+    "duration_s": 488.5,
+    "spotify_uri": "spotify:episode:0e2eFixtureEpisodeIdent",
+    "explicit": false,
+    "chapters": [
+      { "title": "Intro", "start_ms": 0, "source_url": null },
+      {
+        "title": "A chapter whose source URL is longer than the column",
+        "start_ms": 30109,
+        "source_url": "https://techcrunch.com/2026/08/21/private-equity-firm-apollo-confirms-data-breach-amid-hacking-wave-targeting-financial-giants/"
+      },
+      {
+        "title": "A chapter with a short source URL",
+        "start_ms": 79340,
+        "source_url": "https://danluu.com/perf-opt/"
+      },
+      { "title": "Sign-off", "start_ms": 471293, "source_url": null }
+    ]
+  }
+]

--- a/e2e/podcast.spec.ts
+++ b/e2e/podcast.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+// Rendered from e2e/fixtures/podcast-manifest.json, which playwright.config.ts
+// feeds to the web server as EPISODES_MANIFEST_URL. Without it the podcast
+// routes are not generated at all, so these tests fail rather than pass empty.
+const EPISODE_URL = '/podcast/e2e-fixture-episode/';
+
+test.describe('podcast episode page', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('long chapter source URLs wrap instead of overflowing the viewport', async ({ page }) => {
+    await page.goto(EPISODE_URL);
+
+    // Guard against a vacuous pass: if the manifest never loaded there would be
+    // no chapter links to overflow in the first place.
+    await expect(page.locator('ol li a[href^="https://"]')).toHaveCount(2);
+
+    const overflowing = await page.evaluate(() => {
+      const limit = document.documentElement.clientWidth;
+      return [...document.querySelectorAll('main *')]
+        .filter((el) => el.getBoundingClientRect().right > limit + 1)
+        .map((el) => `${el.tagName}: ${(el.textContent ?? '').trim().slice(0, 60)}`);
+    });
+    expect(overflowing).toEqual([]);
+
+    const { clientWidth, scrollWidth } = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,11 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig, devices } from '@playwright/test';
+
+// The podcast routes only exist when EPISODES_MANIFEST_URL resolves, so the
+// suite serves its own fixture manifest inline as a data: URL — no network,
+// no R2 credentials, and production builds stay on the real manifest.
+const fixtureManifest = readFileSync('e2e/fixtures/podcast-manifest.json');
+const EPISODES_MANIFEST_URL = `data:application/json;base64,${fixtureManifest.toString('base64')}`;
 
 export default defineConfig({
   testDir: './e2e',
@@ -19,6 +26,7 @@ export default defineConfig({
     command: process.env.CI ? 'npm run build && npm run preview' : 'npm run dev',
     url: 'http://localhost:4321',
     reuseExistingServer: !process.env.CI,
+    env: { EPISODES_MANIFEST_URL },
     timeout: process.env.CI ? 120_000 : 60_000,
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],

--- a/src/pages/podcast/[slug].astro
+++ b/src/pages/podcast/[slug].astro
@@ -91,7 +91,7 @@ const summary = summaryText(episode.description);
                     <a
                       href={chapter.source_url}
                       rel="noopener"
-                      class="mt-0.5 inline-block truncate text-xs text-[var(--color-dim)] hover:text-[var(--color-amber)]"
+                      class="mt-0.5 inline-block text-xs break-all text-[var(--color-dim)] hover:text-[var(--color-amber)]"
                     >
                       {chapter.source_url}
                     </a>


### PR DESCRIPTION
## Problem

On `/podcast/<slug>` every chapter's source URL ran off the right edge of the page, making the whole document scroll sideways on phones.

The links were styled `inline-block truncate`. That combination never clamps: `truncate` sets `white-space: nowrap`, which makes the element's *min-content* width equal the entire URL string, and an `inline-block`'s shrink-to-fit width can't go below min-content. So instead of ellipsizing, each long URL rendered at its full natural width.

Measured on production at a 375px viewport: `document.documentElement.scrollWidth` was **826** against a `clientWidth` of **375**, with the worst link's right edge at 826px.

## Fix

```diff
-class="mt-0.5 inline-block truncate text-xs ..."
+class="mt-0.5 inline-block text-xs break-all ..."
```

URLs now wrap inside the chapter column. `break-all`, `overflow-wrap: anywhere`, and `break-word` were compared against the real chapter URLs and produce identical line breaks (URLs offer no natural break opportunities), so the explicit form wins.

After the fix: `scrollWidth` 375 = `clientWidth` 375, zero overflowing elements. Checked at 375px, 320px, and desktop.

## Regression gate

Podcast routes only exist when `EPISODES_MANIFEST_URL` resolves, so nothing in CI was rendering these pages at all. This PR adds a self-contained harness:

- `e2e/fixtures/podcast-manifest.json` — a fixture episode with a deliberately over-long chapter URL
- `playwright.config.ts` — feeds it to the web server as a base64 `data:` URL. No network, no R2 credentials, and production builds still use the real manifest.
- `e2e/podcast.spec.ts` — asserts no element in `<main>` overflows the viewport at 375px, and that `scrollWidth <= clientWidth`. It checks the chapter-link count first so it cannot pass vacuously if the fixture ever stops loading.

Confirmed the test fails on the old markup for the right reason, and passes with the fix:

```
Error: expect(received).toEqual(expected)
+   "A: https://techcrunch.com/2026/08/21/private-equity-firm-apollo",
```

## Test results

| Gate | Result |
|---|---|
| `npm run format:check` | clean |
| `npm run lint` | 0 problems |
| `npm run typecheck` | 103 files — 0 errors, 0 warnings, 1 hint (pre-existing `tseslint.config` deprecation) |
| `npm test` | **172 passing, 0 failing** (24 files) |
| `npm run build` | exit 0 |
| `npm run test:e2e` | **11 passed, 1 failed** |

The single e2e failure is `iframe embed › all iframe apps embed without CSP/XFO refusal`, which loads external sites. It fails identically with these changes stashed — the local sandbox's egress proxy also 504s `api.github.com` during the build — so it is environmental, not a regression. It should pass in CI.

## Out of scope

At 320px the **global site header** nav (`About Projects GitHub ↗`) overflows by ~40px on every page — `scrollWidth` 361 vs `clientWidth` 320. Pre-existing and unrelated to the podcast; picked up in a separate session rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
