### PR TITLE
fix(layout): stop the header nav overflowing 320px viewports

### DIFF
--- a/e2e/narrow-viewport.spec.ts
+++ b/e2e/narrow-viewport.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+// The smallest phones we care about (iPhone SE / small Android). Below ~375px the
+// header nav wraps onto its own line; what's asserted here is only that nothing
+// ever spills past the viewport, so the layout is free to reflow as it likes.
+const NARROW = { width: 320, height: 640 };
+
+// Content pages that render the shared header/footer from src/layouts/Base.astro.
+// `/` is excluded — it hydrates the OS shell, which owns its own layout. Episode
+// detail pages (`/podcast/<slug>`) are excluded because their slugs come from a
+// remote manifest at build time; the `/podcast` index is deterministic (the fetch
+// degrades to an empty list) so it is covered here.
+const BASE_LAYOUT_PAGES = ['/about', '/projects', '/blog', '/mythos', '/feeds', '/podcast'];
+
+/** Elements whose right edge sticks out past the viewport, with a 1px slack for
+ * subpixel rounding. Returns tag + class so a failure names the culprit. */
+async function overflowingElements(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const clientWidth = document.documentElement.clientWidth;
+    const offenders = Array.from(document.querySelectorAll('body *'))
+      .filter((el) => el.getBoundingClientRect().right > clientWidth + 1)
+      .map((el) => `<${el.tagName.toLowerCase()} class="${el.getAttribute('class') ?? ''}">`);
+    return {
+      clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      offenders,
+    };
+  });
+}
+
+test.describe('320px viewport', () => {
+  test.use({ viewport: NARROW });
+
+  for (const path of BASE_LAYOUT_PAGES) {
+    test(`${path} has no horizontal overflow`, async ({ page }) => {
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
+      const { clientWidth, scrollWidth, offenders } = await overflowingElements(page);
+      expect(offenders, `elements wider than the ${clientWidth}px viewport`).toEqual([]);
+      expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+    });
+  }
+
+  test('header nav links stay inside the viewport', async ({ page }) => {
+    await page.goto('/about', { waitUntil: 'domcontentloaded' });
+    const nav = page.locator('header nav[aria-label="Primary"]');
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+
+    for (const link of await nav.getByRole('link').all()) {
+      const box = await link.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.x + box!.width).toBeLessThanOrEqual(clientWidth + 1);
+    }
+  });
+});

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -69,17 +69,29 @@ const meta =
     <header
       class="border-b border-[var(--color-border)] bg-[var(--color-void)]/80 backdrop-blur supports-[backdrop-filter]:bg-[var(--color-void)]/60"
     >
-      <div class="mx-auto flex max-w-4xl items-center justify-between gap-4 px-6 py-4 text-sm">
+      <div
+        class="mx-auto flex max-w-4xl flex-wrap items-center justify-between gap-x-3 gap-y-2 px-6 py-4 text-sm sm:gap-x-4"
+      >
         <a href="/" class="transition hover:text-[var(--color-amber)]">
           <Logo size={22} label="cortech.online" />
         </a>
-        <nav aria-label="Primary" class="flex items-center gap-5 text-[var(--color-muted)]">
-          <a href="/about" class="transition hover:text-[var(--color-text)]">About</a>
-          <a href="/projects" class="transition hover:text-[var(--color-text)]">Projects</a>
+        <!-- Sub-`sm` this row keeps a single line down to ~375px (tight gaps, no ↗);
+          narrower than that the nav wraps to its own line rather than overflowing the
+          viewport. `whitespace-nowrap` stops a label breaking apart mid-word. -->
+        <nav
+          aria-label="Primary"
+          class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[var(--color-muted)] sm:gap-x-5"
+        >
+          <a href="/about" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
+            >About</a
+          >
+          <a href="/projects" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
+            >Projects</a
+          >
           <a
             href="https://github.com/schmug"
-            class="transition hover:text-[var(--color-text)]"
-            rel="noopener noreferrer">GitHub ↗</a
+            class="whitespace-nowrap transition hover:text-[var(--color-text)]"
+            rel="noopener noreferrer">GitHub<span class="hidden sm:inline"> ↗</span></a
           >
         </nav>
       </div>


### PR DESCRIPTION
## Problem

At 320px (iPhone SE / small Android) every page using `src/layouts/Base.astro` scrolled horizontally: `document.documentElement.scrollWidth` 361 vs `clientWidth` 320. The header row needs 336px — logo 143 + gap 16 + nav 177 — inside a 272px content box (`max-w-4xl px-6`).

375px wasn't actually clean either. It avoided document overflow only because the `GitHub ↗` link was being squeezed below its natural 60px width and wrapping the arrow onto a second line.

## Fix

`src/layouts/Base.astro` — the header row and the nav now wrap instead of overflowing, with tighter sub-`sm` gaps and the decorative `↗` hidden below `sm` so the single-line header still survives at 375px:

- row: `flex-wrap` + `gap-x-3 gap-y-2 sm:gap-x-4` (was `gap-4`)
- nav: `flex-wrap` + `gap-x-3 gap-y-1 sm:gap-x-5` (was `gap-5`)
- nav links: `whitespace-nowrap` so a label can never break apart mid-word
- `GitHub<span class="hidden sm:inline"> ↗</span>` — arrow returns at `sm` and up

Measured on `/about` with fonts loaded:

| viewport | 280 | 320 | 360 | 375 | 390 | 414 | 640 | 768 | 1280 |
|---|---|---|---|---|---|---|---|---|---|
| scrollWidth == clientWidth | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| header rows | 2 | 2 | 2 | 1 | 1 | 1 | 1 | 1 | 1 |

At ≥640px the rendered header is unchanged from `main`.

The issue's own repro snippet at 320px now returns `{clientWidth: 320, scrollWidth: 320, offenders: []}`.

## Test

New `e2e/narrow-viewport.spec.ts` asserts at 320px that no element's right edge passes `clientWidth`, across the six deterministic Base-layout pages (`/about`, `/projects`, `/blog`, `/mythos`, `/feeds`, `/podcast`), plus a direct bounding-box check on the header nav links. Failures name the offending element.

Pre-fix it failed 6/6, with the same two offenders on every page:

```
+ "<nav class=\"flex items-center gap-5 text-[var(--color-muted)]\">",
+ "<a class=\"transition hover:text-[var(--color-text)]\">",
```

Post-fix:

```
narrow-viewport.spec.ts  7 passed (1.7s)
vitest                   24 files, 172 tests passed
playwright (full)        17 passed, 1 failed
format:check / lint      clean
typecheck                0 errors, 0 warnings
build                    13 pages, Complete!
```

The one Playwright failure is `smoke.spec.ts › iframe embed › all iframe apps embed without CSP/XFO refusal`, which loads live external sites. It fails identically on a stashed clean tree here, so it is pre-existing and unrelated to this change.

## Out of scope

Podcast episode chapter-link wrapping (`/podcast/<slug>`), already handled on `claude/podcasts-link-wrapping-de3d95` — episode detail pages are excluded from the new spec because their slugs come from a remote manifest at build time. The `/podcast` index is deterministic (the manifest fetch degrades to an empty list) and is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)