### PR TITLE
feat(podcast): publish the show's source feed list at /podcast/sources.opml

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -6,6 +6,10 @@
   Content-Type: text/x-opml; charset=utf-8
   Cache-Control: public, max-age=3600
 
+/podcast/sources.opml
+  Content-Type: text/x-opml; charset=utf-8
+  Cache-Control: public, max-age=3600
+
 /
   Link: </.well-known/api-catalog>; rel="api-catalog"
   Link: </rss.xml>; rel="alternate"; type="application/rss+xml"

--- a/scripts/generate-podcast-sources.mjs
+++ b/scripts/generate-podcast-sources.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// scripts/generate-podcast-sources.mjs
+// Regenerates src/lib/podcast-sources.ts from an OPML export.
+//
+// The list is a point-in-time SNAPSHOT of the feeds the daily show reads. It is
+// not wired to the runner's live `opml_files` config — that config lives on the
+// production machine and is in no repo — so refreshing it is a deliberate act:
+// export from Don't Hype Me, drop the file in, re-run this, commit the diff.
+//
+// Vendoring the result as TypeScript rather than parsing OPML at build time is
+// deliberate: the site is a static Astro build, so a remote fetch would make it
+// depend on a third-party repo staying reachable, and a runtime parse would
+// trade type-checked data for regex-parsed XML.
+//
+// Usage: node scripts/generate-podcast-sources.mjs <path-to.opml>
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outPath = resolve(here, '..', 'src', 'lib', 'podcast-sources.ts');
+
+const src = process.argv[2];
+if (!src) {
+  console.error('usage: node scripts/generate-podcast-sources.mjs <path-to.opml>');
+  process.exit(1);
+}
+
+const xml = await readFile(resolve(process.cwd(), src), 'utf8');
+
+const decode = (s) =>
+  s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+
+const attr = (tag, name) => {
+  const m = tag.match(new RegExp(`${name}="([^"]*)"`));
+  return m ? decode(m[1]) : null;
+};
+
+// Group outlines are the ones with no xmlUrl; every feed outline that follows
+// belongs to the most recent group.
+const groups = [];
+let current = null;
+for (const tag of xml.match(/<outline\b[^>]*>/g) ?? []) {
+  const text = attr(tag, 'text');
+  if (!text) continue;
+  if (!/xmlUrl=/.test(tag)) {
+    current = { name: text, feeds: [] };
+    groups.push(current);
+    continue;
+  }
+  if (!current) {
+    current = { name: 'Uncategorized', feeds: [] };
+    groups.push(current);
+  }
+  const xmlUrl = attr(tag, 'xmlUrl');
+  // Refuse to vendor a feed URL carrying a credential. These lists come out of
+  // a personal reader, where an authenticated feed is a plausible mistake, and
+  // this file is published.
+  if (/[?&](token|key|auth|secret|api_?key|password)=/i.test(xmlUrl)) {
+    console.error(`REFUSED (looks credentialed): ${xmlUrl}`);
+    process.exit(1);
+  }
+  current.feeds.push({ title: text, xmlUrl, category: attr(tag, 'category') });
+}
+
+const feedCount = groups.reduce((n, g) => n + g.feeds.length, 0);
+const lit = (s) => JSON.stringify(s);
+
+const body = groups
+  .map(
+    (g) =>
+      `  {\n    name: ${lit(g.name)},\n    feeds: [\n` +
+      g.feeds
+        .map(
+          (f) =>
+            `      { title: ${lit(f.title)}, xmlUrl: ${lit(f.xmlUrl)}` +
+            (f.category ? `, category: ${lit(f.category)}` : '') +
+            ` },`,
+        )
+        .join('\n') +
+      `\n    ],\n  },`,
+  )
+  .join('\n');
+
+const out = `// GENERATED FILE — do not edit by hand.
+// Regenerate: node scripts/generate-podcast-sources.mjs <path-to.opml>
+//
+// A point-in-time snapshot of the feeds the Cortech Daily podcast reads,
+// exported from Don't Hype Me (https://donthype.me). Served as an importable
+// subscription list at /podcast/sources.opml.
+//
+// This is the show's INBOUND list — what it reads. Not to be confused with
+// src/pages/feeds.opml.ts, the OUTBOUND list of feeds this site publishes.
+
+export type SourceFeed = {
+  title: string;
+  xmlUrl: string;
+  /** Don't Hype Me's own taxonomy tags, carried through as OPML \`category\`. */
+  category?: string;
+};
+
+export type SourceGroup = {
+  name: string;
+  feeds: SourceFeed[];
+};
+
+/** ${feedCount} feeds across ${groups.length} groups. */
+export const PODCAST_SOURCE_GROUPS: SourceGroup[] = [
+${body}
+];
+
+export const PODCAST_SOURCE_COUNT = ${feedCount};
+`;
+
+await writeFile(outPath, out);
+console.log(`✓ podcast-sources.ts: ${feedCount} feeds across ${groups.length} groups`);

--- a/src/lib/podcast-sources.ts
+++ b/src/lib/podcast-sources.ts
@@ -1,0 +1,451 @@
+// GENERATED FILE — do not edit by hand.
+// Regenerate: node scripts/generate-podcast-sources.mjs <path-to.opml>
+//
+// A point-in-time snapshot of the feeds the Cortech Daily podcast reads,
+// exported from Don't Hype Me (https://donthype.me). Served as an importable
+// subscription list at /podcast/sources.opml.
+//
+// This is the show's INBOUND list — what it reads. Not to be confused with
+// src/pages/feeds.opml.ts, the OUTBOUND list of feeds this site publishes.
+
+export type SourceFeed = {
+  title: string;
+  xmlUrl: string;
+  /** Don't Hype Me's own taxonomy tags, carried through as OPML `category`. */
+  category?: string;
+};
+
+export type SourceGroup = {
+  name: string;
+  feeds: SourceFeed[];
+};
+
+/** 78 feeds across 11 groups. */
+export const PODCAST_SOURCE_GROUPS: SourceGroup[] = [
+  {
+    name: 'AI',
+    feeds: [
+      {
+        title: '"anthropic" - Google News',
+        xmlUrl: 'https://news.google.com/rss/search?q=anthropic',
+        category: '/type/news',
+      },
+      {
+        title: 'AI',
+        xmlUrl: 'https://blog.google/technology/ai/rss/',
+        category: '/type/corporate',
+      },
+      {
+        title: 'Anthropic',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCrDwWp7EBBv4NwvScIpBDOA',
+        category: '/source/video,/type/corporate',
+      },
+      {
+        title: 'Anthropic Engineering Blog',
+        xmlUrl:
+          'https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_engineering.xml',
+        category: '/type/corporate,/topic/engineering',
+      },
+      {
+        title: 'Anthropic Frontier Red Team Blog',
+        xmlUrl:
+          'https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_red.xml',
+        category: '/type/research,/topic/ai-safety',
+      },
+      {
+        title: 'Anthropic News',
+        xmlUrl:
+          'https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_news.xml',
+        category: '/type/corporate',
+      },
+      {
+        title: 'Anthropic Research',
+        xmlUrl:
+          'https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_research.xml',
+        category: '/type/research',
+      },
+      {
+        title: "Daniel Paleka's Newsletter",
+        xmlUrl: 'https://newsletter.danielpaleka.com/feed',
+        category: '/source/newsletter,/type/people,/topic/ai-safety',
+      },
+      {
+        title: "Don't Worry About the Vase",
+        xmlUrl: 'https://thezvi.substack.com/feed',
+        category: '/source/newsletter,/type/people,/type/analysis',
+      },
+      { title: 'karpathy', xmlUrl: 'https://karpathy.bearblog.dev/rss/', category: '/type/people' },
+      {
+        title: 'Manus AI',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCQgFQdqiFQ_LfFBGP6z9dqQ',
+        category: '/source/video,/type/corporate',
+      },
+      {
+        title: 'Nate’s Substack',
+        xmlUrl: 'https://natesnewsletter.substack.com/feed.xml',
+        category: '/source/newsletter,/type/people',
+      },
+      {
+        title: 'One Useful Thing',
+        xmlUrl: 'https://www.oneusefulthing.org/feed',
+        category: '/source/newsletter,/type/people',
+      },
+      {
+        title: 'OpenAI',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCXZCJLdBC09xxGZ6gcdrc6A',
+        category: '/source/video,/type/corporate',
+      },
+      {
+        title: "Simon Willison's Weblog",
+        xmlUrl: 'https://simonwillison.net/atom/everything/',
+        category: '/type/people,/topic/engineering',
+      },
+    ],
+  },
+  {
+    name: 'Security',
+    feeds: [
+      {
+        title: '2600 - 2600: The Hacker Quarterly',
+        xmlUrl: 'http://www.2600.com/rss.xml',
+        category: '/topic/culture',
+      },
+      {
+        title: 'All CISA Advisories',
+        xmlUrl: 'https://www.cisa.gov/cybersecurity-advisories/all.xml',
+        category: '/topic/government',
+      },
+      {
+        title: 'Articles - ~this week in security~',
+        xmlUrl: 'https://this.weekinsecurity.com/articles/rss/',
+        category: '/type/analysis',
+      },
+      {
+        title: 'CISA News',
+        xmlUrl: 'https://www.cisa.gov/news.xml',
+        category: '/topic/government,/type/news',
+      },
+      {
+        title: 'Cyberpunk Librarian',
+        xmlUrl: 'https://cyberpunklibrarian.com/feed/',
+        category: '/type/people,/topic/culture',
+      },
+      {
+        title: 'Cybersect',
+        xmlUrl: 'https://cybersect.substack.com/feed',
+        category: '/source/newsletter,/type/people',
+      },
+      {
+        title: 'cybersecurity',
+        xmlUrl: 'https://old.reddit.com/r/cybersecurity/.rss',
+        category: '/source/reddit,/type/community',
+      },
+      {
+        title: 'darkreading',
+        xmlUrl: 'https://www.darkreading.com/rss.xml',
+        category: '/type/news',
+      },
+      {
+        title: 'DataBreaches.Net',
+        xmlUrl: 'https://databreaches.net/feed/',
+        category: '/type/news,/topic/breaches',
+      },
+      {
+        title: 'Distributed Email of Secrets',
+        xmlUrl: 'https://ddosecrets.substack.com/feed',
+        category: '/source/newsletter,/topic/leaks,/type/journalism',
+      },
+      {
+        title: 'Have I Been Pwned latest breaches',
+        xmlUrl: 'https://haveibeenpwned.com/feed/breaches/',
+        category: '/topic/breaches',
+      },
+      {
+        title: 'Help Net Security',
+        xmlUrl: 'https://www.helpnetsecurity.com/feed/',
+        category: '/type/news',
+      },
+      {
+        title: 'Jack Rhysider',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCMIqrmh2lMdzhlCPK5ahsAg',
+        category: '/source/video,/source/podcast,/type/people',
+      },
+      {
+        title: 'K-12 Cybersecurity Insider - K12 SIX',
+        xmlUrl: 'https://www.k12six.org/k12-cybersecurity-insider?format=rss',
+        category: '/topic/education',
+      },
+      {
+        title: 'MCNC CNE',
+        xmlUrl: 'https://cne.mcnc.org/feed.xml',
+        category: '/topic/education,/topic/government',
+      },
+      {
+        title: 'Open Source Security',
+        xmlUrl: 'https://seclists.org/rss/oss-sec.rss',
+        category: '/topic/oss',
+      },
+      {
+        title: 'Phrack Magazine',
+        xmlUrl: 'http://iosifache.me/feeds/phrack.xml',
+        category: '/topic/culture',
+      },
+      {
+        title: 'PogoWasRight.org',
+        xmlUrl: 'https://pogowasright.org/feed/',
+        category: '/type/news,/topic/privacy',
+      },
+      {
+        title: 'The DFIR Report',
+        xmlUrl: 'https://thedfirreport.com/feed/',
+        category: '/topic/forensics,/type/research',
+      },
+      {
+        title: 'Zack Whittaker, Author at TechCrunch',
+        xmlUrl: 'https://techcrunch.com/author/zack-whittaker/feed/',
+        category: '/type/people,/type/journalism',
+      },
+    ],
+  },
+  {
+    name: 'Privacy',
+    feeds: [
+      {
+        title: 'Reject Convenience',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UC-ufRLYrXxrIEApGn9VG5pQ',
+        category: '/source/video',
+      },
+      { title: 'Techlore', xmlUrl: 'https://techlore.tech/rss/', category: '/type/people' },
+      {
+        title: 'The Opt Out Project',
+        xmlUrl: 'https://www.optoutproject.net/feed',
+        category: '/type/analysis',
+      },
+    ],
+  },
+  {
+    name: 'Tech News',
+    feeds: [
+      {
+        title: 'Ars Technica - All content',
+        xmlUrl: 'https://feeds.arstechnica.com/arstechnica/index',
+      },
+      {
+        title: 'Hacker News',
+        xmlUrl: 'https://news.ycombinator.com/rss',
+        category: '/type/community',
+      },
+      {
+        title: 'HackerNoon - The Markup',
+        xmlUrl: 'https://hackernoon.com/u/TheMarkup/feed',
+        category: '/type/journalism',
+      },
+      {
+        title: 'MIT Technology Review',
+        xmlUrl: 'https://www.technologyreview.com/feed/',
+        category: '/type/research',
+      },
+      { title: 'TechCrunch', xmlUrl: 'https://techcrunch.com/feed/', category: '/topic/business' },
+      {
+        title: 'The Verge',
+        xmlUrl: 'https://www.theverge.com/rss/index.xml',
+        category: '/topic/culture',
+      },
+      { title: 'WIRED', xmlUrl: 'https://wired.com/feed/rss', category: '/topic/culture' },
+    ],
+  },
+  {
+    name: 'Personal Blogs',
+    feeds: [
+      { title: 'Bram’s Thoughts', xmlUrl: 'https://bramcohen.com/feed', category: '/type/people' },
+      {
+        title: "Dan Shapiro's Blog",
+        xmlUrl: 'https://www.danshapiro.com/blog/feed/',
+        category: '/type/people,/topic/business',
+      },
+      {
+        title: 'Daring Fireball',
+        xmlUrl: 'https://daringfireball.net/feeds/main',
+        category: '/type/people,/topic/apple',
+      },
+      {
+        title: 'daverupert.com',
+        xmlUrl: 'https://daverupert.com/atom.xml',
+        category: '/type/people,/topic/webdev',
+      },
+      {
+        title: 'David Noel Ng',
+        xmlUrl: 'https://dnhkng.github.io/feed.xml',
+        category: '/type/people',
+      },
+      {
+        title: 'Deven Jadhav',
+        xmlUrl: 'https://notes.deven.dev/posts_feed',
+        category: '/type/people,/topic/engineering',
+      },
+      {
+        title: 'Dries Buytaert',
+        xmlUrl: 'https://dri.es/rss.xml',
+        category: '/type/people,/topic/oss',
+      },
+      {
+        title: 'Geoffrey Huntley',
+        xmlUrl: 'https://ghuntley.com/rss/',
+        category: '/type/people,/topic/engineering',
+      },
+      {
+        title: 'So long and thanks for all the fish.',
+        xmlUrl: 'https://jordankasper.com/rss',
+        category: '/type/people',
+      },
+      {
+        title: 'Theo - t3․gg',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCbRP3c757lWg9M-U7TyEkXA',
+        category: '/source/video,/type/people,/topic/webdev',
+      },
+    ],
+  },
+  {
+    name: 'News & Politics',
+    feeds: [
+      {
+        title: '404 Media',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UC7YMZb0X_W06ToOazhFuXIQ',
+        category: '/source/video,/type/journalism,/type/investigative',
+      },
+      {
+        title: 'English - VICE',
+        xmlUrl: 'https://www.vice.com/en/feed/?locale=en_us',
+        category: '/topic/culture',
+      },
+      {
+        title: 'MegaLag',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCwhB8cJTSLxyubnKSS-PLJg',
+        category: '/source/video,/type/journalism,/type/investigative',
+      },
+      {
+        title: 'ProPublica',
+        xmlUrl: 'https://www.propublica.org/feeds/propublica/main',
+        category: '/type/journalism,/type/investigative',
+      },
+      {
+        title: 'The Ezra Klein Show',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCnxuOd8obvLLtf5_-YKFbiQ',
+        category: '/source/video,/source/podcast,/topic/politics,/type/analysis',
+      },
+      {
+        title: 'TheHill.com Just In',
+        xmlUrl: 'https://thehill.com/homenews/feed/',
+        category: '/topic/politics',
+      },
+      { title: 'Top stories - Google News', xmlUrl: 'https://news.google.com/rss' },
+      {
+        title: 'Vox',
+        xmlUrl: 'https://vox.com/rss/index.xml',
+        category: '/topic/politics,/type/analysis',
+      },
+      {
+        title: 'Vox',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCLXo7UDZvByw2ixzpQCufnA',
+        category: '/source/video,/topic/politics',
+      },
+    ],
+  },
+  {
+    name: 'Local NC',
+    feeds: [
+      {
+        title: 'NCGA Joint Legislative Oversight Committee on Information Technology Documents',
+        xmlUrl: 'https://www.ncleg.gov/Documents/RSS/4/',
+        category: '/topic/government',
+      },
+      {
+        title: 'Newport/Morehead City, NC',
+        xmlUrl: 'https://www.weather.gov/rss_page.php?site_name=mhx',
+        category: '/topic/weather',
+      },
+      {
+        title: 'Press Releases',
+        xmlUrl: 'https://www.dpi.nc.gov/news/feed',
+        category: '/topic/government,/topic/education',
+      },
+    ],
+  },
+  {
+    name: 'Sysadmin & IT',
+    feeds: [
+      {
+        title: 'ashes to ashes, rust to rust',
+        xmlUrl: 'https://old.reddit.com/r/iiiiiiitttttttttttt/.rss',
+        category: '/source/reddit,/type/community,/topic/humor',
+      },
+      {
+        title: 'K-12 Systems Administrators',
+        xmlUrl: 'https://old.reddit.com/r/k12sysadmin/.rss',
+        category: '/source/reddit,/type/community,/topic/education',
+      },
+      {
+        title: 'Sysadmin',
+        xmlUrl: 'https://old.reddit.com/r/sysadmin/.rss',
+        category: '/source/reddit,/type/community',
+      },
+    ],
+  },
+  {
+    name: 'Science & Education',
+    feeds: [
+      {
+        title: 'Kurzgesagt – In a Nutshell',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCsXVk37bltHxD1rDPwtNM8Q',
+        category: '/source/video,/topic/education',
+      },
+      {
+        title: 'TED',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCAuUUnT6oDeKwE6v1NGQxug',
+        category: '/source/video,/topic/education,/topic/culture',
+      },
+    ],
+  },
+  {
+    name: 'Humor & Meta',
+    feeds: [
+      {
+        title: 'DepthHub: A jumping-off point for deeply-involved subreddits',
+        xmlUrl: 'https://old.reddit.com/r/DepthHub/.rss',
+        category: '/source/reddit,/type/community',
+      },
+      {
+        title: 'People Who Ate The Onion',
+        xmlUrl: 'https://old.reddit.com/r/AteTheOnion/.rss',
+        category: '/source/reddit,/type/community,/topic/humor',
+      },
+    ],
+  },
+  {
+    name: 'Deep Dive',
+    feeds: [
+      {
+        title: 'Benn Jordan',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCshObcm-nLhbu8MY50EZ5Ng',
+        category: '/source/video,/type/essay,/topic/music,/topic/privacy',
+      },
+      {
+        title: 'CHUPPL',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCizJl3TxBunh-LzpwyPYg0w',
+        category: '/source/video,/type/essay,/type/journalism,/type/investigative',
+      },
+      {
+        title: 'fern',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCODHrzPMGbNv67e84WDZhQQ',
+        category: '/source/video,/type/essay,/type/journalism,/type/investigative',
+      },
+      {
+        title: 'Lauran Irion',
+        xmlUrl: 'https://www.youtube.com/feeds/videos.xml?channel_id=UC2S4560XyLjhrj1P0e7s6zA',
+        category: '/source/video,/type/essay,/topic/culture',
+      },
+    ],
+  },
+];
+
+export const PODCAST_SOURCE_COUNT = 78;

--- a/src/pages/feeds.astro
+++ b/src/pages/feeds.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import { FEEDS } from './feeds.opml';
+import { PODCAST_SOURCE_COUNT } from '../lib/podcast-sources';
 ---
 
 <Base
@@ -23,6 +24,13 @@ import { FEEDS } from './feeds.opml';
         > is the firehose; the rest are topic feeds. Grab them all at once with the
         <a href="/feeds.opml" class="text-[var(--color-amber)] hover:underline">OPML file</a> — most readers
         can import it in one click.
+      </p>
+      <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
+        That file is what this site <em>publishes</em>. For what the podcast <em>reads</em> — the
+        {PODCAST_SOURCE_COUNT} feeds each episode is built from — see <a
+          href="/podcast/sources.opml"
+          class="text-[var(--color-amber)] hover:underline">the source list</a
+        >.
       </p>
     </div>
 

--- a/src/pages/feeds.opml.ts
+++ b/src/pages/feeds.opml.ts
@@ -25,8 +25,9 @@ export const FEEDS: FeedEntry[] = [
     pagePath: '/mythos',
   },
   {
-    title: 'Daily Digest — Cortech',
-    description: 'A daily, AI-narrated digest of links worth your morning',
+    title: 'Cortech Daily',
+    description:
+      'About nine minutes each morning on AI, security, and Cloudflare — every item sourced',
     feedPath: '/podcast/rss.xml',
     pagePath: '/podcast',
   },

--- a/src/pages/podcast/_sources.opml.test.ts
+++ b/src/pages/podcast/_sources.opml.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from './sources.opml';
+import { PODCAST_SOURCE_COUNT, PODCAST_SOURCE_GROUPS } from '../../lib/podcast-sources';
+
+const SITE = new URL('https://cortech.online');
+
+function makeContext() {
+  return { site: SITE } as Parameters<typeof GET>[0];
+}
+
+async function getOpml(): Promise<string> {
+  const res = await GET(makeContext());
+  return await res.text();
+}
+
+describe('podcast sources.opml route', () => {
+  it('serves an OPML 2.0 document', async () => {
+    const xml = await getOpml();
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<opml version="2.0">');
+    expect(xml).toContain('<head>');
+    expect(xml).toContain('<body>');
+  });
+
+  it('serves it as an OPML content type', async () => {
+    const res = await GET(makeContext());
+    // Cloudflare Pages has no MIME entry for .opml and the site sends
+    // X-Content-Type-Options: nosniff, so the type must be explicit here and
+    // mirrored in public/_headers.
+    expect(res.headers.get('content-type')).toMatch(/xml|opml/);
+  });
+
+  it('names itself as the inbound list, distinct from /feeds.opml', async () => {
+    const xml = await getOpml();
+    // /feeds.opml is titled "Cortech feeds" and is what the site publishes.
+    // This file is what the show reads; the titles must not collide.
+    expect(xml).toMatch(/<title>[^<]*sources[^<]*<\/title>/i);
+    expect(xml).not.toContain('<title>Cortech feeds</title>');
+  });
+
+  it('lists every vendored feed as an rss outline', async () => {
+    const xml = await getOpml();
+    const feedOutlines = xml.match(/<outline\b[^>]*type="rss"[^>]*\/>/g) ?? [];
+    expect(feedOutlines.length).toBe(PODCAST_SOURCE_COUNT);
+    expect(feedOutlines.length).toBe(78);
+  });
+
+  it('nests the feeds under their group folders', async () => {
+    const xml = await getOpml();
+    // Group outlines are containers: they open, hold children, and close.
+    const groupOpens = xml.match(/<outline text="[^"]*"(?!.*xmlUrl)[^>]*>\n/g) ?? [];
+    expect(groupOpens.length).toBe(PODCAST_SOURCE_GROUPS.length);
+    expect(xml).toContain('text="AI"');
+    expect(xml).toContain('text="Security"');
+    // A reader importing this should get folders, not 78 loose feeds.
+    expect((xml.match(/<\/outline>/g) ?? []).length).toBe(PODCAST_SOURCE_GROUPS.length);
+  });
+
+  it('publishes no feed URL carrying a credential', async () => {
+    const xml = await getOpml();
+    const urls = [...xml.matchAll(/xmlUrl="([^"]+)"/g)].map((m) => m[1]);
+    expect(urls.length).toBe(78);
+    for (const u of urls) {
+      expect(u).toMatch(/^https?:\/\//);
+      expect(u).not.toMatch(/[?&](token|key|auth|secret|api_?key|password)=/i);
+    }
+  });
+
+  it('escapes titles containing XML metacharacters', async () => {
+    const xml = await getOpml();
+    // The export contains titles with quotes and ampersands, e.g. the
+    // "anthropic" Google News feed and the "News & Politics" group.
+    expect(xml).not.toMatch(/text="[^"]*[<>]/);
+    expect(xml).toContain('&amp;');
+    expect(xml).toContain('&quot;');
+  });
+
+  it('credits the tool by product URL, never the private repo', async () => {
+    const xml = await getOpml();
+    expect(xml).toContain('donthype.me');
+    // github.com/schmug/donthype-me is private; linking it would 404.
+    expect(xml).not.toContain('github.com/schmug/donthype-me');
+  });
+});

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../../layouts/Base.astro';
 import { fetchEpisodes, formatChapterTimestamp, summaryText } from '../../lib/episodes';
+import { PODCAST_SOURCE_COUNT } from '../../lib/podcast-sources';
 
 const episodes = await fetchEpisodes();
 
@@ -13,10 +14,10 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 
 <Base
   title="Podcast"
-  description="Daily Digest — a daily AI-narrated digest of links worth your morning. By Cory Schmug."
+  description="Cortech Daily — about nine minutes each morning on AI, security, and Cloudflare, every item linked to its source. By Schmug."
   canonical="https://cortech.online/podcast"
   feedUrl="/podcast/rss.xml"
-  feedTitle="Daily Digest — Cortech"
+  feedTitle="Cortech Daily"
 >
   <section class="mx-auto max-w-2xl px-6 pt-16 pb-10">
     <div>
@@ -24,12 +25,22 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
         Podcast
       </p>
       <h1 class="mt-2 text-3xl font-[var(--font-display)] font-bold tracking-tight sm:text-4xl">
-        Daily Digest
+        Cortech Daily
       </h1>
       <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
         AI-narrated daily walk through the links in my morning queue. Subscribe via the
         <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a
         >. Individual episodes also publish to Spotify — see the per-episode page for the link.
+      </p>
+      <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
+        Want the sources instead of the summary? The <a
+          href="/podcast/sources.opml"
+          class="text-[var(--color-amber)] hover:underline"
+          >{PODCAST_SOURCE_COUNT} feeds this show reads</a
+        > are published as an OPML file your reader can import in one click — curated in <a
+          href="https://donthype.me"
+          class="text-[var(--color-amber)] hover:underline">Don't Hype Me</a
+        >. It's a snapshot, not a live mirror of my reader.
       </p>
     </div>
 

--- a/src/pages/podcast/sources.opml.ts
+++ b/src/pages/podcast/sources.opml.ts
@@ -1,0 +1,69 @@
+import type { APIContext } from 'astro';
+import { PODCAST_SOURCE_GROUPS } from '../../lib/podcast-sources';
+
+// OPML 2.0 subscription list of the feeds the Cortech Daily podcast *reads* —
+// the show's provenance, importable into any reader in one click.
+//
+// Do not confuse this with /feeds.opml. That one is OUTBOUND (the feeds this
+// site publishes, for subscribing to us); this one is INBOUND (what the show
+// consumes). Both are OPML, and they mean opposite things, so the <title> of
+// each has to make the direction obvious.
+//
+// The list is a point-in-time snapshot vendored in src/lib/podcast-sources.ts,
+// not the runner's live config — see that file's header before refreshing it.
+
+const OPML_TITLE = 'Cortech Daily — podcast sources';
+const OWNER_NAME = 'Schmug';
+// Credit the product, never github.com/schmug/donthype-me: that repo is
+// private and the link would 404 for every listener who followed it.
+const CURATED_IN = 'https://donthype.me';
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET(_context: APIContext) {
+  const body = PODCAST_SOURCE_GROUPS.map((group) => {
+    const feeds = group.feeds
+      .map((feed) => {
+        const category = feed.category ? ` category="${escapeXml(feed.category)}"` : '';
+        return (
+          `      <outline type="rss" text="${escapeXml(feed.title)}"` +
+          ` title="${escapeXml(feed.title)}"` +
+          ` xmlUrl="${escapeXml(feed.xmlUrl)}"${category} />`
+        );
+      })
+      .join('\n');
+    return `    <outline text="${escapeXml(group.name)}" title="${escapeXml(group.name)}">\n${feeds}\n    </outline>`;
+  }).join('\n');
+
+  const opml = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head>
+    <title>${escapeXml(OPML_TITLE)}</title>
+    <ownerName>${escapeXml(OWNER_NAME)}</ownerName>
+    <docs>${escapeXml(CURATED_IN)}</docs>
+  </head>
+  <body>
+${body}
+  </body>
+</opml>
+`;
+
+  return new Response(opml, {
+    headers: {
+      // Mirrored by a public/_headers override — Cloudflare Pages serves static
+      // assets by extension, and `.opml` isn't in its MIME map. With the global
+      // X-Content-Type-Options: nosniff, the served type has to be set explicitly.
+      'content-type': 'text/x-opml; charset=utf-8',
+      'cache-control': 'public, max-age=3600',
+    },
+  });
+}
+
+export const prerender = true;


### PR DESCRIPTION
Closes #189.

For a links-digest show, the list of feeds it reads is the show's provenance. This publishes it as an importable OPML file, turning "trust me, I read a lot" into an artifact a listener can load into their own reader in one click.

## What's here

`/podcast/sources.opml` — **78 feeds across 11 group folders** (AI, Security, Privacy, Tech News, Personal Blogs, News & Politics, Local NC, Sysadmin & IT, Science & Education, Humor & Meta, Deep Dive), vendored in `src/lib/podcast-sources.ts` and generated from a Don't Hype Me export by `scripts/generate-podcast-sources.mjs`.

Plus human-readable entry points on `/podcast` and `/feeds`.

## Decisions worth reviewing

**Vendored, not fetched.** This is a static Astro build, so fetching the list from `schmug/opml-backup` at build time would make the build depend on a third-party repo staying reachable and unchanged. The list is committed and regenerated deliberately.

**It's a snapshot, and the copy says so.** The runner's live `opml_files` config isn't in any repo, so this can't auto-sync. Rather than imply it does, the page says *"It's a snapshot, not a live mirror of my reader"* and the generated file's header documents the refresh loop. Measured against the 75 published episodes, the list accounts for 557/745 (75%) of cited source domains — real but partial coverage, some of the rest arriving via the Google News and Reddit search feeds already in the list.

**Two OPML files now mean opposite things.** `/feeds.opml` is **outbound** (feeds this site publishes); `/podcast/sources.opml` is **inbound** (feeds the show reads). Both surfaces name the direction explicitly, their `<title>`s differ, and a test pins that they don't collide.

**Credential safety.** These lists come out of a personal reader, where an authenticated feed URL is a plausible mistake — and this file is published. The generator hard-refuses any `xmlUrl` carrying a token/key/auth/secret param, and a test asserts none of the 78 published URLs do. I scanned the current list: all 78 are public and unauthenticated.

**Don't Hype Me is credited by product URL** (`donthype.me`), not `schmug/donthype-me` — that repo is private, so the link would 404 for every listener. A test pins this too.

## Drive-by cleanup

The #188 rename changed the feed but left the website still branded "Daily Digest" — the `/podcast` page heading, its meta description (which also still credited "Cory Schmug"), and the `feeds.opml.ts` entry. Fixed here since this PR touches those files anyway; flagging it because it's slightly outside the issue's stated scope.

## Verification

```
format:check  All matched files use Prettier code style!
lint          clean
typecheck     109 files: 0 errors, 0 warnings, 1 hint
test          25 files, 186 passed, 0 failed   (was 178; +8 new)
build         /podcast/sources.opml emitted, Complete!
```

Built output parsed as XML: **11 groups, 78 feeds**, title `Cortech Daily — podcast sources`. Served over HTTP in dev with `content-type: text/x-opml; charset=utf-8` (the route sets it *and* `public/_headers` mirrors it — Cloudflare Pages has no MIME entry for `.opml`, and with global `nosniff` one without the other fails).

Both changed pages verified in the browser, no console errors:

> That file is what this site *publishes*. For what the podcast *reads* — the 78 feeds each episode is built from — see the source list.

## Follow-up

`schmug/clodcast#130` adds the episode-description footer pointing listeners here. Deliberately *not* in the channel description — Spotify's playbook wants the first two lines link-free, with promotional content last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)