### PR TITLE
feat: link the Spotify shows from the homepage, nav, and show pages

### DIFF
--- a/e2e/spotify-links.spec.ts
+++ b/e2e/spotify-links.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { SHOWS } from '../src/lib/shows';
+
+// Both shows are listed on Spotify, which is where listeners actually are. The
+// link is the whole point of the surface, so assert the exact href rather than
+// just "a link exists" — a `?si=` share token or a stale show id would still
+// render a perfectly clickable, wrong link.
+
+test.describe('show pages link Spotify', () => {
+  for (const show of SHOWS) {
+    test(`${show.pagePath} links ${show.name} on Spotify, feed intact`, async ({ page }) => {
+      await page.goto(show.pagePath);
+
+      const spotify = page.getByRole('link', { name: /listen on spotify/i });
+      await expect(spotify).toBeVisible();
+      await expect(spotify).toHaveAttribute('href', show.spotifyUrl);
+
+      // Spotify leads, but the feed is what a podcast client subscribes to.
+      await expect(page.locator(`main a[href="${show.feedPath}"]`).first()).toBeVisible();
+    });
+  }
+});
+
+test.describe('homepage static layer', () => {
+  // The static layer is hidden the moment JS runs, so it can only be asserted
+  // with JS off — which is also exactly how crawlers and no-JS visitors see it.
+  test.use({ javaScriptEnabled: false });
+
+  test('lists both shows with their Spotify links', async ({ page }) => {
+    await page.goto('/');
+
+    const podcasts = page.locator('#static-layer section', { hasText: 'Podcasts' }).first();
+    await expect(podcasts).toBeVisible();
+
+    for (const show of SHOWS) {
+      await expect(podcasts.getByRole('link', { name: show.name })).toHaveAttribute(
+        'href',
+        show.pagePath,
+      );
+      await expect(
+        podcasts.locator(`a[href="${show.spotifyUrl}"]`),
+        `${show.name} Spotify link`,
+      ).toBeVisible();
+      await expect(podcasts.getByRole('img', { name: `${show.name} cover art` })).toBeVisible();
+    }
+  });
+
+  test('offers Podcasts in the header nav', async ({ page }) => {
+    await page.goto('/');
+    await expect(
+      page.locator('#static-layer header').getByRole('link', { name: 'Podcasts' }),
+    ).toHaveAttribute('href', '/podcast');
+  });
+});
+
+test.describe('CortechOS Podcasts app', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  // Fonts are blocked because page.goto otherwise hangs on document.fonts.ready.
+  test.beforeEach(async ({ page }) => {
+    await page.route(/fonts\.(googleapis|gstatic)\.com/, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/css', body: '' }),
+    );
+  });
+
+  test('opens from its desktop icon and links both shows out to Spotify', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const splash = page.locator('[aria-label="CortechOS booting"]');
+    await splash.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    await page.keyboard.press('Space');
+    await splash.waitFor({ state: 'hidden', timeout: 10_000 });
+    await expect(page.locator('#ct-desktop')).toBeVisible({ timeout: 15_000 });
+
+    await page.locator('button[aria-label="Open Podcasts"]').click();
+    const win = page.locator('section[aria-label="Podcasts window"]');
+    await expect(win).toBeVisible();
+
+    for (const show of SHOWS) {
+      await expect(win.getByRole('heading', { name: show.name })).toBeVisible();
+      await expect(win.locator(`a[href="${show.spotifyUrl}"]`)).toHaveCount(1);
+      await expect(win.locator(`a[href="${show.pagePath}"]`)).toHaveCount(1);
+    }
+  });
+});

--- a/src/apps/registry.ts
+++ b/src/apps/registry.ts
@@ -48,6 +48,17 @@ export const apps: AppManifest[] = [
     allowMultiple: false,
   },
   {
+    id: 'podcasts',
+    name: 'Podcasts',
+    description: 'Cortech Daily and Frontier Commits — on Spotify or by feed.',
+    icon: '🎙️',
+    type: 'native',
+    component: () => import('../components/os/apps/PodcastsApp'),
+    defaultSize: { w: 720, h: 620 },
+    minSize: { w: 380, h: 420 },
+    allowMultiple: false,
+  },
+  {
     id: 'support',
     name: 'Support',
     description: 'Sponsor, tip, or star my work.',

--- a/src/components/os/apps/PodcastsApp.test.tsx
+++ b/src/components/os/apps/PodcastsApp.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import PodcastsApp from './PodcastsApp';
+import { SHOWS } from '../../../lib/shows';
+
+afterEach(cleanup);
+
+describe('PodcastsApp', () => {
+  it('renders one section per show', () => {
+    render(<PodcastsApp />);
+    for (const show of SHOWS) {
+      expect(screen.getByRole('heading', { name: show.name })).toBeTruthy();
+    }
+  });
+
+  it.each(SHOWS)('$name links out to Spotify, its episodes, and its feed', (show) => {
+    render(<PodcastsApp />);
+    const card = screen.getByRole('heading', { name: show.name }).closest('article');
+    expect(card).not.toBeNull();
+
+    const spotify = within(card as HTMLElement).getByRole('link', { name: /spotify/i });
+    expect(spotify.getAttribute('href')).toBe(show.spotifyUrl);
+    // Cross-origin target=_blank without noopener hands the opened tab a live
+    // window.opener handle back into CortechOS.
+    expect(spotify.getAttribute('rel')).toContain('noopener');
+
+    const episodes = within(card as HTMLElement).getByRole('link', { name: /episodes/i });
+    expect(episodes.getAttribute('href')).toBe(show.pagePath);
+
+    const feed = within(card as HTMLElement).getByRole('link', { name: /rss/i });
+    expect(feed.getAttribute('href')).toBe(show.feedPath);
+  });
+
+  it.each(SHOWS)('$name shows its cover art with a non-decorative alt', (show) => {
+    render(<PodcastsApp />);
+    const cover = screen.getByRole('img', { name: new RegExp(`${show.name} cover`, 'i') });
+    expect(cover.getAttribute('src')).toBe(show.coverSrc);
+  });
+});

--- a/src/components/os/apps/PodcastsApp.tsx
+++ b/src/components/os/apps/PodcastsApp.tsx
@@ -1,0 +1,68 @@
+import { SHOWS, type Show } from '../../../lib/shows';
+
+export default function PodcastsApp() {
+  return (
+    <div className="h-full overflow-y-auto bg-[var(--color-void)] px-7 py-6 text-[var(--color-text)]">
+      <header>
+        <div className="font-mono text-[11px] tracking-[0.3em] text-[var(--color-amber)] uppercase">
+          Podcasts
+        </div>
+        <h1 className="mt-1 text-2xl font-[var(--font-display)] font-semibold tracking-tight">
+          Two shows, both AI-narrated.
+        </h1>
+        <p className="mt-2 text-sm text-[var(--color-muted)]">
+          Written and produced by Schmug. Both are on Spotify — or paste the feed into whatever
+          player you already use.
+        </p>
+      </header>
+
+      <section className="mt-6 flex flex-col gap-4">
+        {SHOWS.map((show) => (
+          <ShowCard key={show.id} show={show} />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function ShowCard({ show }: { show: Show }) {
+  return (
+    <article className="flex flex-col gap-4 rounded-[var(--ct-radius)] border border-[var(--color-border)] bg-[var(--color-panel)]/40 p-4 sm:flex-row">
+      <img
+        src={show.coverSrc}
+        alt={`${show.name} cover art`}
+        width="1400"
+        height="1400"
+        className="h-20 w-20 shrink-0 self-start rounded-md border border-[var(--color-border)]"
+      />
+      <div className="min-w-0">
+        <h2 className="text-lg font-[var(--font-display)] font-semibold tracking-tight">
+          {show.name}
+        </h2>
+        <p className="mt-1 text-sm text-[var(--color-muted)]">{show.tagline}</p>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+          <a
+            href={show.spotifyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-md bg-[var(--color-amber)] px-3 py-1.5 font-medium text-[var(--color-void)] transition hover:opacity-90"
+          >
+            Listen on Spotify ↗
+          </a>
+          <a
+            href={show.pagePath}
+            className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-[var(--color-text)] transition hover:border-[var(--color-amber)] hover:text-[var(--color-amber)]"
+          >
+            All episodes
+          </a>
+          <a
+            href={show.feedPath}
+            className="font-mono text-[var(--color-muted)] transition hover:text-[var(--color-amber)]"
+          >
+            RSS
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -88,6 +88,9 @@ const meta =
           <a href="/projects" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
             >Projects</a
           >
+          <a href="/podcast" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
+            >Podcasts</a
+          >
           <a
             href="https://github.com/schmug"
             class="whitespace-nowrap transition hover:text-[var(--color-text)]"

--- a/src/lib/shows.test.ts
+++ b/src/lib/shows.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { SHOWS } from './shows';
+
+describe('SHOWS', () => {
+  it('carries both published shows', () => {
+    expect(SHOWS.map((s) => s.id)).toEqual(['cortech-daily', 'frontier-commits']);
+  });
+
+  // The Spotify URL is the one link a listener actually clicks. A `?si=` share
+  // token pasted straight from the Spotify app attributes every visit to
+  // whichever device copied it, so canonicalize on the way in.
+  it.each(SHOWS)('$id links a canonical, tracker-free Spotify show URL', (show) => {
+    expect(show.spotifyUrl).toMatch(/^https:\/\/open\.spotify\.com\/show\/[A-Za-z0-9]+$/);
+    expect(show.spotifyUrl).not.toContain('?');
+  });
+
+  it.each(SHOWS)('$id points at a site page and a feed that exist', (show) => {
+    expect(show.pagePath).toMatch(/^\/[a-z-]+$/);
+    expect(show.feedPath).toBe(`${show.pagePath}/rss.xml`);
+    expect(show.coverSrc).toMatch(/^\/[\w-]+\.(png|jpg)$/);
+  });
+
+  it.each(SHOWS)('$id has a tagline short enough for a card', (show) => {
+    expect(show.name.length).toBeGreaterThan(0);
+    expect(show.tagline.length).toBeLessThanOrEqual(140);
+  });
+});

--- a/src/lib/shows.ts
+++ b/src/lib/shows.ts
@@ -1,0 +1,49 @@
+// The two podcasts, as one list. Both shows surface in four places — their own
+// show page, the homepage static layer, the CortechOS Podcasts app, and the
+// primary nav — and the Spotify URL is the piece most likely to be pasted in
+// wrong, so it lives here once.
+//
+// Spotify's share sheet appends a `?si=` token that attributes every click to
+// the device that copied the link. The canonical form is the bare show URL;
+// shows.test.ts fails the build if a tracked one lands here.
+//
+// This is the *shows* list. src/pages/feeds.opml.ts is the feeds list — it
+// covers every feed the site publishes, podcasts included.
+
+export type Show = {
+  id: string;
+  name: string;
+  /** One line, card-sized. Shown on the homepage and in the Podcasts app. */
+  tagline: string;
+  /** The show's page on this site. */
+  pagePath: string;
+  feedPath: string;
+  /** Square cover art under /public, 1400px source. */
+  coverSrc: string;
+  spotifyUrl: string;
+};
+
+export const SHOWS: Show[] = [
+  {
+    id: 'cortech-daily',
+    name: 'Cortech Daily',
+    tagline:
+      'About nine minutes each morning on AI, security, and Cloudflare — every item linked to its source.',
+    pagePath: '/podcast',
+    feedPath: '/podcast/rss.xml',
+    coverSrc: '/podcast-cover.png',
+    spotifyUrl: 'https://open.spotify.com/show/2r9MIeNT0aVkbcaLRUeMqM',
+  },
+  {
+    id: 'frontier-commits',
+    name: 'Frontier Commits',
+    tagline:
+      'Weekly, on what Anthropic, OpenAI, Google DeepMind, and xAI actually shipped on GitHub.',
+    pagePath: '/frontier-commits',
+    feedPath: '/frontier-commits/rss.xml',
+    coverSrc: '/frontier-commits-cover.jpg',
+    spotifyUrl: 'https://open.spotify.com/show/1F8PcfKYdslkqwhKHt9jLV',
+  },
+];
+
+export const showById = (id: string): Show | undefined => SHOWS.find((s) => s.id === id);

--- a/src/pages/frontier-commits/index.astro
+++ b/src/pages/frontier-commits/index.astro
@@ -2,8 +2,10 @@
 import Base from '../../layouts/Base.astro';
 import { formatChapterTimestamp, summaryText } from '../../lib/episodes';
 import { fetchFrontierEpisodes } from '../../lib/frontierEpisodes';
+import { showById } from '../../lib/shows';
 
 const episodes = await fetchFrontierEpisodes();
+const show = showById('frontier-commits')!;
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -44,12 +46,20 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
       </div>
     </div>
 
-    <p class="mt-6 max-w-xl text-sm text-[var(--color-muted)]">
-      Subscribe in any podcast app with the <a
-        href="/frontier-commits/rss.xml"
-        class="text-[var(--color-amber)] hover:underline">show feed</a
-      > — it carries the audio, so paste it straight into your player.
-    </p>
+    <div class="mt-6 flex flex-wrap items-center gap-x-4 gap-y-2">
+      <a
+        href={show.spotifyUrl}
+        rel="noopener noreferrer"
+        class="rounded-md bg-[var(--color-amber)] px-4 py-2 text-sm font-medium text-[var(--color-void)] transition hover:opacity-90"
+        >Listen on Spotify ↗</a
+      >
+      <p class="text-sm text-[var(--color-muted)]">
+        or subscribe in any player with the <a
+          href="/frontier-commits/rss.xml"
+          class="text-[var(--color-amber)] hover:underline">show feed</a
+        > — it carries the audio.
+      </p>
+    </div>
 
     {
       episodes.length === 0 ? (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import RootShell from '../components/RootShell.tsx';
 import { apps } from '../apps/registry.ts';
+import { SHOWS } from '../lib/shows.ts';
 
 const flagships = apps.filter((a) => a.type === 'iframe');
 ---
@@ -59,6 +60,7 @@ const flagships = apps.filter((a) => a.type === 'iframe');
           <nav class="flex items-center gap-5 text-[var(--color-muted)]">
             <a href="/about" class="hover:text-[var(--color-text)]">About</a>
             <a href="/projects" class="hover:text-[var(--color-text)]">Projects</a>
+            <a href="/podcast" class="hover:text-[var(--color-text)]">Podcasts</a>
             <a
               href="https://github.com/schmug"
               rel="noopener noreferrer"
@@ -105,6 +107,43 @@ const flagships = apps.filter((a) => a.type === 'iframe');
                     </a>
                   </div>
                   <p class="mt-1 text-sm text-[var(--color-dim)]">{app.description}</p>
+                </li>
+              ))
+            }
+          </ul>
+        </section>
+
+        <section class="mt-10">
+          <h2 class="font-mono text-[11px] tracking-[0.25em] text-[var(--color-muted)] uppercase">
+            Podcasts
+          </h2>
+          <ul class="mt-4 grid gap-3 sm:grid-cols-2">
+            {
+              SHOWS.map((show) => (
+                <li class="flex gap-3 rounded-[var(--ct-radius)] border border-[var(--color-border)] p-4">
+                  <img
+                    src={show.coverSrc}
+                    alt={`${show.name} cover art`}
+                    width="1400"
+                    height="1400"
+                    class="h-12 w-12 shrink-0 rounded-md border border-[var(--color-border)]"
+                  />
+                  <div class="min-w-0">
+                    <a
+                      href={show.pagePath}
+                      class="font-medium text-[var(--color-text)] hover:text-[var(--color-amber)]"
+                    >
+                      {show.name}
+                    </a>
+                    <p class="mt-1 text-sm text-[var(--color-dim)]">{show.tagline}</p>
+                    <a
+                      href={show.spotifyUrl}
+                      rel="noopener noreferrer"
+                      class="mt-2 inline-block text-sm text-[var(--color-amber)] hover:underline"
+                    >
+                      Listen on Spotify ↗
+                    </a>
+                  </div>
                 </li>
               ))
             }

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -2,8 +2,10 @@
 import Base from '../../layouts/Base.astro';
 import { fetchEpisodes, formatChapterTimestamp, summaryText } from '../../lib/episodes';
 import { PODCAST_SOURCE_COUNT } from '../../lib/podcast-sources';
+import { showById } from '../../lib/shows';
 
 const episodes = await fetchEpisodes();
+const show = showById('cortech-daily')!;
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -28,10 +30,23 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
         Cortech Daily
       </h1>
       <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
-        AI-narrated daily walk through the links in my morning queue. Subscribe via the
-        <a href="/podcast/rss.xml" class="text-[var(--color-amber)] hover:underline">podcast feed</a
-        >. Individual episodes also publish to Spotify — see the per-episode page for the link.
+        AI-narrated daily walk through the links in my morning queue.
       </p>
+
+      <div class="mt-5 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <a
+          href={show.spotifyUrl}
+          rel="noopener noreferrer"
+          class="rounded-md bg-[var(--color-amber)] px-4 py-2 text-sm font-medium text-[var(--color-void)] transition hover:opacity-90"
+          >Listen on Spotify ↗</a
+        >
+        <p class="text-sm text-[var(--color-muted)]">
+          or subscribe in any player with the <a
+            href="/podcast/rss.xml"
+            class="text-[var(--color-amber)] hover:underline">show feed</a
+          >.
+        </p>
+      </div>
       <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
         Want the sources instead of the summary? The <a
           href="/podcast/sources.opml"


### PR DESCRIPTION
Cortech Daily and Frontier Commits are both live on Spotify, but nothing on the site said so. `/podcast` still told listeners to dig into a per-episode page for the link, and Frontier Commits offered only the feed.

## What changed

Both shows now live in [`src/lib/shows.ts`](src/lib/shows.ts), so the Spotify URL is written once instead of in the four places that surface it.

| Surface | Change |
|---|---|
| `/podcast`, `/frontier-commits` | Lead with a **Listen on Spotify** button; the show feed drops to the line beneath it |
| Homepage static layer | New **Podcasts** section with both covers, taglines, and Spotify links — the layer crawlers and no-JS visitors get |
| Primary nav (`Base.astro`) + static header | **Podcasts** → `/podcast` |
| CortechOS | Native **Podcasts** app (🎙️) listing both shows |

Spotify's share sheet appends a `?si=` token that attributes every click back to whichever device copied the link. `shows.test.ts` fails the build if a tracked URL lands in the list — the two URLs here are canonical.

**No Spotify iframe player.** Embedding one would mean widening `frame-src` in [`public/_headers`](public/_headers) to include `open.spotify.com`. Links cost nothing, so the CSP is untouched.

## Verification

```
npm run format:check   All matched files use Prettier code style!
npm run lint           clean
npm run typecheck      Result (121 files): 0 errors, 0 warnings, 1 hint
npm test               Test Files 29 passed (29) | Tests 229 passed (229)
npm run build          15 page(s) built, Complete!
```

Playwright, new spec [`e2e/spotify-links.spec.ts`](e2e/spotify-links.spec.ts):

```
✓ /podcast links Cortech Daily on Spotify, feed intact
✓ /frontier-commits links Frontier Commits on Spotify, feed intact
✓ homepage static layer lists both shows with their Spotify links
✓ homepage static layer offers Podcasts in the header nav
✓ CortechOS Podcasts app opens from its desktop icon and links both shows out
5 passed (3.9s)
```

The static-layer tests run with `javaScriptEnabled: false` — that layer is hidden the moment JS runs, so it had no coverage before and can only be asserted with JS off.

Adding a 4th nav item was the one real risk, since [`narrow-viewport.spec.ts`](e2e/narrow-viewport.spec.ts) asserts nav links stay inside a 320px viewport. It holds — **8 passed**, including `header nav links stay inside the viewport`.

Full suite: **29 passed, 1 failed** — `iframe embed › all iframe apps embed without CSP/XFO refusal`. That failure is pre-existing and unrelated: I confirmed it by stashing this branch's changes and re-running it on a clean tree, where it fails identically (upstream `donthype.me`/`dmarc.mx` framing, tracked separately).

Also verified in the browser: both show pages, the rendered Podcasts app window, and the built `dist/index.html` carrying both canonical `open.spotify.com/show/…` hrefs with no tracking params.

## Follow-up

`.claude/skills/add-app` step 2 tells you to hand-bump a springboard tile count in `e2e/smoke.spec.ts`, but that assertion is already derived from `apps.length` — the instruction is stale. Left out of this diff; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
