### PR TITLE
feat: add a /podcasts index and point the Podcasts nav at it

### DIFF
--- a/e2e/narrow-viewport.spec.ts
+++ b/e2e/narrow-viewport.spec.ts
@@ -17,6 +17,7 @@ const BASE_LAYOUT_PAGES = [
   '/blog',
   '/mythos',
   '/feeds',
+  '/podcasts',
   '/podcast',
   '/frontier-commits',
 ];

--- a/e2e/spotify-links.spec.ts
+++ b/e2e/spotify-links.spec.ts
@@ -21,6 +21,52 @@ test.describe('show pages link Spotify', () => {
   }
 });
 
+test.describe('/podcasts index', () => {
+  // The nav item has always been labelled "Podcasts" while landing on Cortech
+  // Daily's own show page. This page is what the plural promises: every show in
+  // one place, rendered from SHOWS so a third one needs no edit here.
+
+  test('renders a complete card for every show', async ({ page }) => {
+    await page.goto('/podcasts');
+
+    for (const show of SHOWS) {
+      const card = page.locator('main li', { hasText: show.name }).first();
+
+      await expect(card.getByRole('link', { name: show.name })).toHaveAttribute(
+        'href',
+        show.pagePath,
+      );
+      await expect(
+        card.locator(`a[href="${show.spotifyUrl}"]`),
+        `${show.name} Spotify link`,
+      ).toBeVisible();
+      await expect(
+        card.locator(`a[href="${show.feedPath}"]`),
+        `${show.name} feed link`,
+      ).toBeVisible();
+      await expect(card.getByRole('img', { name: `${show.name} cover art` })).toBeVisible();
+    }
+  });
+
+  test('is where the primary nav sends Podcasts', async ({ page }) => {
+    await page.goto('/about');
+    await expect(
+      page.locator('header nav[aria-label="Primary"]').getByRole('link', { name: 'Podcasts' }),
+    ).toHaveAttribute('href', '/podcasts');
+  });
+
+  // /podcast and /podcasts are one character apart and both land in the
+  // sitemap. Distinct canonicals are what keeps them from reading as a
+  // duplicate of each other.
+  test('declares its own canonical', async ({ page }) => {
+    await page.goto('/podcasts');
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      'https://cortech.online/podcasts',
+    );
+  });
+});
+
 test.describe('homepage static layer', () => {
   // The static layer is hidden the moment JS runs, so it can only be asserted
   // with JS off — which is also exactly how crawlers and no-JS visitors see it.
@@ -49,7 +95,7 @@ test.describe('homepage static layer', () => {
     await page.goto('/');
     await expect(
       page.locator('#static-layer header').getByRole('link', { name: 'Podcasts' }),
-    ).toHaveAttribute('href', '/podcast');
+    ).toHaveAttribute('href', '/podcasts');
   });
 });
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -88,7 +88,7 @@ const meta =
           <a href="/projects" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
             >Projects</a
           >
-          <a href="/podcast" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
+          <a href="/podcasts" class="whitespace-nowrap transition hover:text-[var(--color-text)]"
             >Podcasts</a
           >
           <a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,7 +60,7 @@ const flagships = apps.filter((a) => a.type === 'iframe');
           <nav class="flex items-center gap-5 text-[var(--color-muted)]">
             <a href="/about" class="hover:text-[var(--color-text)]">About</a>
             <a href="/projects" class="hover:text-[var(--color-text)]">Projects</a>
-            <a href="/podcast" class="hover:text-[var(--color-text)]">Podcasts</a>
+            <a href="/podcasts" class="hover:text-[var(--color-text)]">Podcasts</a>
             <a
               href="https://github.com/schmug"
               rel="noopener noreferrer"

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -1,0 +1,73 @@
+---
+// The directory page for the shows. /podcast is Cortech Daily's own page and
+// keeps that URL — it is the one Spotify ingests a feed from — so this is the
+// plural the "Podcasts" nav item has always promised. Rendered straight from
+// SHOWS: adding a third show needs no edit here.
+//
+// Sibling of /feeds, which is the same idea for every feed the site publishes.
+import Base from '../layouts/Base.astro';
+import { SHOWS } from '../lib/shows';
+---
+
+<Base
+  title="Podcasts"
+  description="Cortech Daily and Frontier Commits — both AI-narrated, both on Spotify, both available as feeds for any podcast player."
+  canonical="https://cortech.online/podcasts"
+>
+  <section class="mx-auto max-w-2xl px-6 pt-16 pb-10">
+    <div>
+      <p class="font-mono text-[11px] tracking-[0.35em] text-[var(--color-amber)] uppercase">
+        Podcasts
+      </p>
+      <h1 class="mt-2 text-3xl font-[var(--font-display)] font-bold tracking-tight sm:text-4xl">
+        Listen to Cortech
+      </h1>
+      <p class="mt-3 max-w-xl text-sm text-[var(--color-muted)]">
+        Each show is AI-narrated, and every item links back to the source it came from. Spotify is
+        the quickest way in — the <a href="/feeds" class="text-[var(--color-amber)] hover:underline"
+          >feeds</a
+        > work in any podcast player.
+      </p>
+    </div>
+
+    <ul class="mt-10 space-y-5">
+      {
+        SHOWS.map((show) => (
+          <li class="flex gap-4 rounded-[var(--ct-radius)] border border-[var(--color-border)] p-5">
+            <img
+              src={show.coverSrc}
+              alt={`${show.name} cover art`}
+              width="1400"
+              height="1400"
+              class="h-20 w-20 shrink-0 rounded-md border border-[var(--color-border)]"
+            />
+            <div class="min-w-0">
+              <a
+                href={show.pagePath}
+                class="text-lg font-[var(--font-display)] font-semibold tracking-tight hover:text-[var(--color-amber)]"
+              >
+                {show.name}
+              </a>
+              <p class="mt-1 text-sm text-[var(--color-muted)]">{show.tagline}</p>
+              <div class="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+                <a
+                  href={show.spotifyUrl}
+                  rel="noopener noreferrer"
+                  class="rounded-md bg-[var(--color-amber)] px-4 py-2 text-sm font-medium text-[var(--color-void)] transition hover:opacity-90"
+                >
+                  Listen on Spotify ↗
+                </a>
+                <a
+                  href={show.feedPath}
+                  class="font-mono text-xs text-[var(--color-amber)] hover:underline"
+                >
+                  {show.feedPath}
+                </a>
+              </div>
+            </div>
+          </li>
+        ))
+      }
+    </ul>
+  </section>
+</Base>


### PR DESCRIPTION
Follow-up to #198, which left this as an open question. The primary nav has been labelled **Podcasts** while landing on `/podcast` — Cortech Daily's own show page. Frontier Commits was reachable only from the homepage static layer or a cross-link on the daily show page.

`/podcasts` is the plural that label promised.

## What changed

New page [`src/pages/podcasts.astro`](src/pages/podcasts.astro), rendered straight from [`SHOWS`](src/lib/shows.ts) — a third show would appear with no edit to the page. Each card carries cover art, tagline, a **Listen on Spotify** button, and the show's feed.

| Surface | Change |
|---|---|
| `/podcasts` | New — the directory page for both shows |
| Primary nav ([`Base.astro:91`](src/layouts/Base.astro:91)) | `Podcasts` → `/podcasts` |
| Homepage static header ([`index.astro:63`](src/pages/index.astro:63)) | `Podcasts` → `/podcasts` |

Structurally it is a sibling of [`/feeds`](src/pages/feeds.astro) — same idea, applied to shows rather than every feed the site publishes.

**`/podcast` keeps its URL.** It is the feed Spotify ingests (`/podcast/rss.xml`) and the base of every episode permalink already shipped in the RSS. Moving it would have bought a tidier hierarchy at the cost of breaking published links, so the two pages carry distinct canonicals instead — the one-character gap is handled in metadata, not by a redirect. The other six `/podcast` references in the tree genuinely mean Cortech Daily and are untouched.

**No Spotify iframe**, consistent with #198 — embedding one would mean widening `frame-src` in [`public/_headers`](public/_headers). Links cost nothing, so the CSP is unchanged.

## Tests first

The two nav assertions were flipped to `/podcasts` and failed against the live `href="/podcast"`; the new `/podcasts index` block failed on a 404. Four red, for the right reasons, before the page existed:

```
✘ /podcasts index › renders a complete card for every show
✘ /podcasts index › is where the primary nav sends Podcasts
✘ /podcasts index › declares its own canonical
✘ homepage static layer › offers Podcasts in the header nav
  4 failed, 4 passed
```

The new block loops over `SHOWS`, so the coverage grows with the data rather than with hand-written cases. `/podcasts` also joins the 320px sweep in [`narrow-viewport.spec.ts`](e2e/narrow-viewport.spec.ts) — verified at 320px, nav on one line, nothing spilling past the viewport.

## Verification

```
npm run format:check   All matched files use Prettier code style!
npm run lint           clean
npm run typecheck      Result (122 files): 0 errors, 0 warnings, 1 hint
npm test               Test Files 29 passed (29) | Tests 229 passed (229)
npm run build          16 page(s) built, Complete!
```

Full Playwright suite — **33 passed, 1 skipped, 0 failed**:

```
✓ /podcasts index › renders a complete card for every show
✓ /podcasts index › is where the primary nav sends Podcasts
✓ /podcasts index › declares its own canonical
✓ homepage static layer › offers Podcasts in the header nav
✓ 320px viewport › /podcasts has no horizontal overflow
- iframe embed › all iframe apps embed without CSP/XFO refusal   (skipped)
```

That skip is pre-existing and by design: the test `test.skip()`s under `CI` because the external CSPs pin `frame-ancestors` to the prod origin, which localhost is not.

Browser-checked on the running dev server at desktop and 320px: no console errors, canonical resolves to `https://cortech.online/podcasts`, and both Spotify hrefs render in their canonical tracker-free form with no `?si=` token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
