### PR TITLE
feat(mythos): generate posts via Claude Code CLI instead of the API key

### DIFF
--- a/.github/workflows/mythos.yml
+++ b/.github/workflows/mythos.yml
@@ -25,11 +25,30 @@ jobs:
 
       - run: npm ci
 
+      # Generation goes through the Claude Code CLI so the tracker bills the
+      # Claude subscription (CLAUDE_CODE_OAUTH_TOKEN) rather than API credits.
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Verify Claude auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is not set. Generate one with 'claude setup-token' and add it as a repo secret."
+            exit 1
+          fi
+          # Fail loudly on a dead token here rather than after the payload diff,
+          # so an auth problem can never hide behind an unchanged-payload no-op.
+          echo "ping" | claude -p --restricted --output-format json --model claude-sonnet-4-6 \
+            --append-system-prompt 'Reply with the single word: ok' > /tmp/auth-probe.json
+          node -e 'const r=require("/tmp/auth-probe.json"); if(r.is_error||typeof r.result!=="string"){console.error("::error::Claude auth probe failed:",JSON.stringify(r).slice(0,400));process.exit(1)} console.log("auth ok:",r.result.trim())'
+
       - name: Run tracker
         id: tracker
-        run: npm run mythos:run
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: npm run mythos:run
 
       - name: Configure git
         if: steps.tracker.outputs.branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.104.2",
         "@astrojs/check": "^0.9.9",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.61.0",
@@ -47,28 +46,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@astrojs/check": {
@@ -186,9 +163,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -204,9 +178,6 @@
       "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -224,9 +195,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -242,9 +210,6 @@
       "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -833,9 +798,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -848,9 +810,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -865,9 +824,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -880,9 +836,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2476,9 +2429,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,9 +2444,6 @@
       "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2514,9 +2461,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2532,9 +2476,6 @@
       "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2552,9 +2493,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2570,9 +2508,6 @@
       "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3084,13 +3019,6 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3223,9 +3151,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3241,9 +3166,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3261,9 +3183,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3279,9 +3198,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4856,9 +4772,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4878,9 +4791,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4902,9 +4812,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4924,9 +4831,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6565,13 +6469,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "dev": true,
-      "license": "Unlicense"
-    },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
@@ -7934,20 +7831,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -10204,17 +10087,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -10595,13 +10467,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.104.2",
     "@astrojs/check": "^0.9.9",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.61.0",

--- a/scripts/mythos/llm.test.ts
+++ b/scripts/mythos/llm.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { claudeCliCallLlm, type CliResult } from './llm';
+
+const ok = (result: string): CliResult => ({
+  stdout: JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result }),
+  stderr: '',
+  code: 0,
+});
+
+describe('claudeCliCallLlm', () => {
+  it('returns the result field on success', async () => {
+    const callLlm = claudeCliCallLlm({
+      model: 'claude-sonnet-4-6',
+      run: async () => ok('body text'),
+    });
+    await expect(callLlm('sys', 'user')).resolves.toBe('body text');
+  });
+
+  it('invokes the CLI in restricted print mode with the system prompt and pipes user text on stdin', async () => {
+    let seenArgs: string[] = [];
+    let seenStdin = '';
+    const callLlm = claudeCliCallLlm({
+      model: 'claude-sonnet-4-6',
+      run: async (args, stdin) => {
+        seenArgs = args;
+        seenStdin = stdin;
+        return ok('x');
+      },
+    });
+    await callLlm('SYSTEM', 'USER');
+
+    expect(seenArgs).toContain('-p');
+    // No tool use for a pure text generation call.
+    expect(seenArgs).toContain('--restricted');
+    expect(seenArgs).toContain('--output-format');
+    expect(seenArgs).toContain('json');
+    expect(seenArgs).toContain('--model');
+    expect(seenArgs[seenArgs.indexOf('--model') + 1]).toBe('claude-sonnet-4-6');
+    expect(seenArgs[seenArgs.indexOf('--append-system-prompt') + 1]).toBe('SYSTEM');
+    expect(seenStdin).toBe('USER');
+  });
+
+  it('throws with stderr when the CLI exits non-zero (e.g. expired OAuth token)', async () => {
+    const callLlm = claudeCliCallLlm({
+      model: 'm',
+      run: async () => ({ stdout: '', stderr: 'Invalid API key · Please run /login', code: 1 }),
+    });
+    await expect(callLlm('s', 'u')).rejects.toThrow(/Invalid API key/);
+  });
+
+  it('throws when the CLI reports is_error', async () => {
+    const callLlm = claudeCliCallLlm({
+      model: 'm',
+      run: async () => ({
+        stdout: JSON.stringify({
+          type: 'result',
+          subtype: 'error_during_execution',
+          is_error: true,
+          result: 'nope',
+        }),
+        stderr: '',
+        code: 0,
+      }),
+    });
+    await expect(callLlm('s', 'u')).rejects.toThrow(/nope/);
+  });
+
+  it('throws when stdout is not valid JSON', async () => {
+    const callLlm = claudeCliCallLlm({
+      model: 'm',
+      run: async () => ({ stdout: 'not json', stderr: '', code: 0 }),
+    });
+    await expect(callLlm('s', 'u')).rejects.toThrow(/parse/i);
+  });
+
+  it('throws when the payload has no string result', async () => {
+    const callLlm = claudeCliCallLlm({
+      model: 'm',
+      run: async () => ({
+        stdout: JSON.stringify({ type: 'result', is_error: false }),
+        stderr: '',
+        code: 0,
+      }),
+    });
+    await expect(callLlm('s', 'u')).rejects.toThrow(/result/i);
+  });
+});

--- a/scripts/mythos/llm.ts
+++ b/scripts/mythos/llm.ts
@@ -1,0 +1,92 @@
+import { execFile } from 'node:child_process';
+
+export type CallLlm = (system: string, user: string) => Promise<string>;
+
+export type CliResult = { stdout: string; stderr: string; code: number };
+
+/** Injectable so tests never spawn a real process. */
+export type CliRunner = (args: string[], stdin: string) => Promise<CliResult>;
+
+export type ClaudeCliOpts = {
+  model: string;
+  bin?: string;
+  timeoutMs?: number;
+  maxBuffer?: number;
+  run?: CliRunner;
+};
+
+const DEFAULT_TIMEOUT_MS = 180_000;
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
+ * Text generation through the Claude Code CLI rather than the Anthropic SDK, so
+ * the tracker bills a Claude subscription (CLAUDE_CODE_OAUTH_TOKEN) instead of
+ * API credits. Same `(system, user) => text` contract renderPost already
+ * depends on, so its retry/validation loop is unchanged.
+ *
+ * Throws on any non-success outcome — renderPost treats a throw as a failed
+ * attempt and retries, and surfaces the message when it runs out of attempts.
+ */
+export function claudeCliCallLlm(opts: ClaudeCliOpts): CallLlm {
+  const run = opts.run ?? nodeRunner(opts);
+  return async (system, user) => {
+    const args = [
+      '-p',
+      // Pure text generation: strip the tool-running built-ins.
+      '--restricted',
+      '--output-format',
+      'json',
+      '--model',
+      opts.model,
+      '--append-system-prompt',
+      system,
+    ];
+
+    const { stdout, stderr, code } = await run(args, user);
+    if (code !== 0) {
+      throw new Error(`claude CLI exited ${code}: ${(stderr || stdout).trim() || '(no output)'}`);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new Error(`could not parse claude CLI output as JSON: ${stdout.slice(0, 200)}`);
+    }
+
+    const payload = parsed as { is_error?: boolean; result?: unknown; subtype?: string };
+    if (payload.is_error) {
+      throw new Error(
+        `claude CLI reported an error (${payload.subtype ?? 'unknown'}): ${String(payload.result ?? '')}`,
+      );
+    }
+    if (typeof payload.result !== 'string' || payload.result.length === 0) {
+      throw new Error(`claude CLI returned no result text: ${stdout.slice(0, 200)}`);
+    }
+    return payload.result;
+  };
+}
+
+function nodeRunner(opts: ClaudeCliOpts): CliRunner {
+  return (args, stdin) =>
+    new Promise((resolve, reject) => {
+      const child = execFile(
+        opts.bin ?? 'claude',
+        args,
+        {
+          timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          maxBuffer: opts.maxBuffer ?? DEFAULT_MAX_BUFFER,
+        },
+        (err, stdout, stderr) => {
+          // execFile reports a non-zero exit as an error carrying `code`; that
+          // is a normal result here, not a spawn failure.
+          if (err && typeof (err as { code?: unknown }).code !== 'number') {
+            reject(err);
+            return;
+          }
+          resolve({ stdout, stderr, code: (err as { code?: number } | null)?.code ?? 0 });
+        },
+      );
+      child.stdin?.end(stdin);
+    });
+}

--- a/scripts/mythos/run.ts
+++ b/scripts/mythos/run.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import Anthropic from '@anthropic-ai/sdk';
 import { existsSync, readFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -7,13 +6,13 @@ import { fetchPayload } from './fetch';
 import { digest } from './digest';
 import { triggersFor } from './triggers';
 import { renderPost } from './generate';
+import { claudeCliCallLlm } from './llm';
 import type { Post } from './generate';
 import { writePostAndSnapshot } from './write';
 import type { Digest } from './types';
 
 const PAYLOAD_URL = 'https://red.anthropic.com/2026/cvd/data/payload.json';
 const MODEL = 'claude-sonnet-4-6';
-const MAX_TOKENS = 1024;
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
 const POSTS_DIR = join(REPO_ROOT, 'src/content/mythos');
 const SNAPSHOT_PATH = join(POSTS_DIR, '_data/snapshot.json');
@@ -61,18 +60,7 @@ async function main(): Promise<void> {
     triggers.map((t) => t.kind),
   );
 
-  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-  const callLlm = async (system: string, user: string): Promise<string> => {
-    const msg = await client.messages.create({
-      model: MODEL,
-      max_tokens: MAX_TOKENS,
-      system,
-      messages: [{ role: 'user', content: user }],
-    });
-    const block = msg.content[0];
-    if (block.type !== 'text') throw new Error('expected text response');
-    return block.text;
-  };
+  const callLlm = claudeCliCallLlm({ model: MODEL });
 
   const allKnownCves = newDigest.revealed_cve_ids;
   const post = await renderPost({


### PR DESCRIPTION
Fixes the Mythos tracker failures in [#205](https://github.com/schmug/cortech.online/issues/205) / [#206](https://github.com/schmug/cortech.online/issues/206), and moves generation off API credits onto a Claude subscription.

## What was actually wrong

Both failed runs died the same way:

```
[mythos] FATAL: generation failed after retry: callLlm threw: 401
{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}
```

`401 / authentication_error` = revoked key, not a model or quota problem. That key has since been rotated, so the API path is dead by choice.

### The part worth keeping in mind

Every "successful" run from May through Aug 26 was a **no-op**:

```
[mythos] payload as_of=2026-05-22T17:27:03.605363Z unchanged; exiting cleanly
```

`run.ts` short-circuits on an unchanged payload *before* constructing the API client, so three months of green checkmarks never once exercised the credential. When upstream finally moved on Aug 27, the first real call found a dead key. The checkmarks were never evidence the tracker worked.

## Changes

- **`scripts/mythos/llm.ts` (new)** — drives `claude -p --restricted --output-format json --model … --append-system-prompt …` with the user prompt on stdin, parses the result envelope, and throws on non-zero exit, `is_error`, unparseable stdout, or a missing `result` string. Same throw contract `renderPost`'s retry loop already handles. The `CliRunner` is injectable so tests never spawn a process.
- **`scripts/mythos/run.ts`** — `renderPost` already took `callLlm` as an injected `(system, user) => Promise<string>` ([generate.ts:53](../blob/main/scripts/mythos/generate.ts#L53)), so the backend swaps in one line without touching the tested pipeline.
- **`.github/workflows/mythos.yml`** — installs the CLI, switches the secret to `CLAUDE_CODE_OAUTH_TOKEN`, and adds a **pre-flight auth probe that runs before the payload diff**, so a dead token fails loudly on the next run instead of hiding behind an unchanged-payload no-op.
- **`package.json`** — drops `@anthropic-ai/sdk`; `run.ts` was its only consumer.

## Deploy note — blocking

This needs a repo secret before the next scheduled run, generated against the subscription:

```
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo schmug/cortech.online
```

The old `ANTHROPIC_API_KEY` secret can be deleted afterwards.

## Verification

Real dry run against the live payload (`as_of=2026-08-26`, 118 CVE/GHSA IDs, 112 projects, **228 triggers** — 94 revealed, 108 new_project, 24 bug_class_shift, 2 funnel_shift):

```
word count : 247  (gate: 120-400)
unique IDs mentioned: 94   (all required CVEs cited)
```

The ~3-month catch-up post fits the word gate — identifiers pack densely enough that 94 IDs still leave room for prose.

```
format:check  All matched files use Prettier code style!
lint          clean
typecheck     Result (124 files): 0 errors, 0 warnings, 1 hint
test          Test Files 30 passed (30) | Tests 235 passed (235)
build         16 page(s) built
```

New `llm.test.ts` covers 6 cases: success, argv/stdin shape, non-zero exit surfacing stderr (the expired-token case), `is_error`, unparseable stdout, missing result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)