### PR TITLE
fix(mythos): emit prettier-clean frontmatter so generated posts pass CI

### DIFF
--- a/scripts/mythos/write.test.ts
+++ b/scripts/mythos/write.test.ts
@@ -70,4 +70,30 @@ describe('writePostAndSnapshot()', () => {
     const snap = JSON.parse(readFileSync(snapPath, 'utf8'));
     expect(snap.revealed_cve_ids).toEqual(['CVE-2026-0001', 'CVE-2026-0002']);
   });
+
+  it('emits markdown that is already prettier-clean, even with many ids', async () => {
+    // A real catch-up post carries ~94 identifiers and ~112 projects. Inline
+    // flow arrays blow past printWidth, so prettier rewrites the file and
+    // format:check fails CI on every generated post.
+    const many: Post = {
+      ...post,
+      frontmatter: {
+        ...post.frontmatter,
+        cve_ids: Array.from({ length: 94 }, (_, i) => `CVE-2026-${10000 + i}`),
+        projects: Array.from({ length: 112 }, (_, i) => `org-${i}/project-${i}`),
+      },
+    };
+    writePostAndSnapshot({
+      post: many,
+      digest,
+      postsDir: join(dir, 'src/content/mythos'),
+      snapshotPath: join(dir, 'src/content/mythos/_data/snapshot.json'),
+    });
+    const written = readFileSync(join(dir, `src/content/mythos/${many.slug}.md`), 'utf8');
+
+    const prettier = await import('prettier');
+    const config = await prettier.resolveConfig('post.md');
+    const formatted = await prettier.format(written, { ...config, parser: 'markdown' });
+    expect(formatted).toBe(written);
+  });
 });

--- a/scripts/mythos/write.ts
+++ b/scripts/mythos/write.ts
@@ -25,9 +25,9 @@ function renderMarkdown(post: Post): string {
     `title: ${yamlString(fm.title)}`,
     `description: ${yamlString(fm.description)}`,
     `pubDate: ${fm.pubDate}`,
-    `triggers: [${fm.triggers.map(yamlString).join(', ')}]`,
-    `cve_ids: [${fm.cve_ids.map(yamlString).join(', ')}]`,
-    `projects: [${fm.projects.map(yamlString).join(', ')}]`,
+    yamlList('triggers', fm.triggers),
+    yamlList('cve_ids', fm.cve_ids),
+    yamlList('projects', fm.projects),
     `headline_snapshot:`,
     `  disclosed: ${fm.headline_snapshot.disclosed}`,
     `  acknowledged: ${fm.headline_snapshot.acknowledged}`,
@@ -35,6 +35,17 @@ function renderMarkdown(post: Post): string {
     `  advisories: ${fm.headline_snapshot.advisories}`,
   ].join('\n');
   return `---\n${yaml}\n---\n\n${post.body}\n`;
+}
+
+/**
+ * Block-style sequence, one item per line. A catch-up post carries ~94
+ * identifiers and ~112 projects; as an inline flow array that overruns
+ * prettier's printWidth, so prettier rewrites the file and every generated
+ * post fails format:check in CI. Block style is stable at any length.
+ */
+function yamlList(key: string, items: string[]): string {
+  if (items.length === 0) return `${key}: []`;
+  return [`${key}:`, ...items.map((i) => `  - ${yamlString(i)}`)].join('\n');
 }
 
 function yamlString(s: string): string {


### PR DESCRIPTION
`writePostAndSnapshot` rendered `triggers`/`cve_ids`/`projects` as inline YAML flow arrays. A real catch-up post carries ~94 identifiers and ~112 projects, which overruns prettier's `printWidth`, so prettier rewrites the file and `format:check` fails on **every generated post** — as it just did on #213.

This was invisible until now: PRs pushed with the default `GITHUB_TOKEN` never trigger CI (#136), so no generated post had ever actually been checked. Pushing a commit under a real account on #213 surfaced it immediately.

Emits block-style sequences instead, which are stable at any length (verified against this repo's prettier config). Empty lists stay `[]` — an empty block sequence isn't valid YAML, and the bootstrap post has empty arrays.

The test renders a post with 94 ids and 112 projects and asserts `prettier.format` over the output is a no-op. That encodes the CI invariant directly rather than pinning a particular formatting style, so it keeps holding if the prettier config changes.

```
format:check  All matched files use Prettier code style!
lint          clean
typecheck     0 errors, 0 warnings
test          Test Files 30 passed (30) | Tests 236 passed (236)
build         16 page(s) built
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)