### PR TITLE
chore(mythos): hand the daily schedule to the Claude Code routine

### DIFF
--- a/.github/workflows/mythos.yml
+++ b/.github/workflows/mythos.yml
@@ -1,8 +1,10 @@
 name: Mythos tracker
 
 on:
-  schedule:
-    - cron: '0 19 * * *' # 2pm EST / 3pm EDT
+  # The daily schedule now lives in the "Mythos tracker" Claude Code routine,
+  # which runs on the Claude subscription and opens PRs under a real account so
+  # required checks actually fire (PRs pushed with GITHUB_TOKEN never trigger
+  # workflows — see #136). This workflow stays as a manual fallback.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removes the `schedule:` trigger from `mythos.yml`. The daily run now lives in the **Mythos tracker** routine (`trig_01UUGcvedAmxmCiYCLWRKwQp`, environment `mysites`, `0 19 * * *` UTC — the same slot). `workflow_dispatch` is kept, so the Actions path remains a working manual fallback.

## Why

PRs pushed with the default `GITHUB_TOKEN` never trigger workflows, so required checks never report and auto-merge can never resolve (#136). That is exactly what stalled #213 — it sat `BLOCKED` with `no checks reported` until a commit was pushed under a real account. The routine pushes as a real account, so checks fire normally.

## Verified

The routine's fetch and no-op path work, after `*.anthropic.com` was allowlisted for the environment (before that, the sandbox's egress proxy returned HTTP 403 while the same URL returned 200 elsewhere):

```
[mythos] fetching https://red.anthropic.com/2026/cvd/data/payload.json
[mythos] payload as_of=2026-08-26T18:55:53.809770Z unchanged; exiting cleanly
```

Clean exit in 26s, no files touched, no branch, no PR — correct behavior for the ~daily case, confirmed across two runs.

## NOT verified

The write path — nested `claude -p` generation, `git push`, `gh pr create`, `gh pr merge --auto` — has **not** run, because the snapshot is current so no triggers fire. It first executes whenever upstream `as_of` moves.

If it fails there the routine reports it and nothing is silently lost. Recovery is `gh workflow run "Mythos tracker"` plus a commit pushed to the generated branch to trigger CI — the same manual sequence that landed #213. Worst case is a late post, not a broken pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)