### PR TITLE
feat(mythos): mine the payload ledger for post narrative

### DIFF
--- a/scripts/mythos/digest.test.ts
+++ b/scripts/mythos/digest.test.ts
@@ -46,4 +46,43 @@ describe('digest()', () => {
     expect(d.as_of).toBe('2026-05-23T17:27:03Z');
     expect(d.fetched_at).toBe('2026-05-24T19:00:00Z');
   });
+  it('aggregates the ledger, carrying a denominator for every sparse figure', () => {
+    const d = digest(rawNew, '2026-05-24T19:00:00Z');
+    expect(d.ledger?.total).toBe(16);
+    expect(d.ledger?.withdrawals).toEqual({ total: 8, by_reason: { duplicate: 3, mistake: 5 } });
+    expect(d.ledger?.funnel).toEqual({
+      acknowledged_by_maintainer: 2,
+      discovered: 9,
+      revealed: 3,
+      sent: 2,
+    });
+    expect(d.ledger?.severity_agreement).toEqual({
+      rated_pairs: 4,
+      agree: 1,
+      disagree: 3,
+      claude_higher: 2,
+      maintainer_higher: 1,
+      disagree_pct: 75,
+    });
+    expect(d.ledger?.latency.discovery_to_reveal).toEqual({
+      median_days: 100,
+      sample: 3,
+      excluded_negative: 0,
+    });
+  });
+
+  it('excludes the fixture patch dated before its discovery from the median', () => {
+    const d = digest(rawNew, '2026-05-24T19:00:00Z');
+    expect(d.ledger?.latency.discovery_to_patch).toEqual({
+      median_days: 45,
+      sample: 2,
+      excluded_negative: 1,
+    });
+  });
+
+  it('omits the ledger block for a payload that has no ledger', () => {
+    const withoutLedger = { ...rawNew };
+    delete withoutLedger.ledger;
+    expect(digest(withoutLedger, '2026-05-24T19:00:00Z').ledger).toBeUndefined();
+  });
 });

--- a/scripts/mythos/digest.ts
+++ b/scripts/mythos/digest.ts
@@ -1,3 +1,5 @@
+import { aggregateLedger } from './ledger';
+import type { LedgerEntry } from './ledger';
 import type { Digest, SeverityBucket } from './types';
 
 type RawPayload = {
@@ -26,6 +28,7 @@ type RawPayload = {
     identifier: string;
     findings: Array<{ project: string; bug_class: string; ecosystem: string }>;
   }>;
+  ledger?: LedgerEntry[];
 };
 
 export function digest(raw: RawPayload, fetchedAt: string): Digest {
@@ -59,5 +62,6 @@ export function digest(raw: RawPayload, fetchedAt: string): Digest {
     by_ecosystem: { ...raw.by_ecosystem },
     project_names: projectNames,
     revealed_cve_ids: cveIds,
+    ...(raw.ledger ? { ledger: aggregateLedger(raw.ledger) } : {}),
   };
 }

--- a/scripts/mythos/fixtures/payload-new.json
+++ b/scripts/mythos/fixtures/payload-new.json
@@ -12,25 +12,214 @@
   },
   "median_days_to_ack": 7,
   "median_days_to_patch": 21,
-  "by_bug_class": { "heap-buffer-overflow": 130, "xss": 40 },
+  "by_bug_class": {
+    "heap-buffer-overflow": 130,
+    "xss": 40
+  },
   "by_ecosystem": {
-    "Other": { "critical": 4, "high": 12, "medium": 5, "low": 0, "unknown": 0 }
+    "Other": {
+      "critical": 4,
+      "high": 12,
+      "medium": 5,
+      "low": 0,
+      "unknown": 0
+    }
   },
   "by_project": [
-    { "project": "wolfSSL", "ecosystem": "Other", "cve_ids": ["CVE-2026-0001", "CVE-2026-0002"] },
-    { "project": "curl", "ecosystem": "Other", "cve_ids": ["CVE-2026-9001"] }
+    {
+      "project": "wolfSSL",
+      "ecosystem": "Other",
+      "cve_ids": ["CVE-2026-0001", "CVE-2026-0002"]
+    },
+    {
+      "project": "curl",
+      "ecosystem": "Other",
+      "cve_ids": ["CVE-2026-9001"]
+    }
   ],
   "cve_records": [
     {
       "identifier": "CVE-2026-0001",
       "findings": [
-        { "project": "wolfSSL", "bug_class": "heap-buffer-overflow", "ecosystem": "Other" }
+        {
+          "project": "wolfSSL",
+          "bug_class": "heap-buffer-overflow",
+          "ecosystem": "Other"
+        }
       ]
     },
     {
       "identifier": "CVE-2026-0002",
-      "findings": [{ "project": "wolfSSL", "bug_class": "use-after-free", "ecosystem": "Other" }]
+      "findings": [
+        {
+          "project": "wolfSSL",
+          "bug_class": "use-after-free",
+          "ecosystem": "Other"
+        }
+      ]
     }
   ],
-  "ghsa_records": []
+  "ghsa_records": [],
+  "ledger": [
+    {
+      "claude_severity": "high",
+      "maintainer_severity": "medium",
+      "discovered_on": "2026-03-01",
+      "revealed_at": "2026-06-09T00:00:00Z",
+      "patched_at": "2026-04-10T00:00:00Z",
+      "reveal_tier": "revealed",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": "high",
+      "maintainer_severity": "high",
+      "discovered_on": "2026-03-01",
+      "revealed_at": "2026-05-30T00:00:00Z",
+      "patched_at": "2026-04-20T00:00:00Z",
+      "reveal_tier": "revealed",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": "critical",
+      "maintainer_severity": "medium",
+      "discovered_on": "2026-03-01",
+      "revealed_at": "2026-06-19T00:00:00Z",
+      "patched_at": null,
+      "reveal_tier": "revealed",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": "medium",
+      "maintainer_severity": "high",
+      "discovered_on": "2026-03-01",
+      "revealed_at": null,
+      "patched_at": "2026-02-01T00:00:00Z",
+      "reveal_tier": "acknowledged_by_maintainer",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": "high",
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "acknowledged_by_maintainer",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": "high",
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "sent",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "sent",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "mistake"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "mistake"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "mistake"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "mistake"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "mistake"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "duplicate"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "duplicate"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "duplicate"
+    }
+  ]
 }

--- a/scripts/mythos/fixtures/payload-old.json
+++ b/scripts/mythos/fixtures/payload-old.json
@@ -12,20 +12,139 @@
   },
   "median_days_to_ack": 7,
   "median_days_to_patch": 21,
-  "by_bug_class": { "heap-buffer-overflow": 100, "xss": 40 },
+  "by_bug_class": {
+    "heap-buffer-overflow": 100,
+    "xss": 40
+  },
   "by_ecosystem": {
-    "Other": { "critical": 4, "high": 10, "medium": 5, "low": 0, "unknown": 0 }
+    "Other": {
+      "critical": 4,
+      "high": 10,
+      "medium": 5,
+      "low": 0,
+      "unknown": 0
+    }
   },
   "by_project": [
-    { "project": "wolfSSL", "ecosystem": "Other", "cve_ids": ["CVE-2026-0001", "CVE-2026-0002"] }
+    {
+      "project": "wolfSSL",
+      "ecosystem": "Other",
+      "cve_ids": ["CVE-2026-0001", "CVE-2026-0002"]
+    }
   ],
   "cve_records": [
     {
       "identifier": "CVE-2026-0001",
       "findings": [
-        { "project": "wolfSSL", "bug_class": "heap-buffer-overflow", "ecosystem": "Other" }
+        {
+          "project": "wolfSSL",
+          "bug_class": "heap-buffer-overflow",
+          "ecosystem": "Other"
+        }
       ]
     }
   ],
-  "ghsa_records": []
+  "ghsa_records": [],
+  "ledger": [
+    {
+      "claude_severity": "high",
+      "maintainer_severity": "medium",
+      "discovered_on": "2026-03-01",
+      "revealed_at": "2026-06-09T00:00:00Z",
+      "patched_at": null,
+      "reveal_tier": "revealed",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": "high",
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "acknowledged_by_maintainer",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "sent",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "sent",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "sent",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "sent",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": false,
+      "withdrawn_reason": null
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "mistake"
+    },
+    {
+      "claude_severity": null,
+      "maintainer_severity": null,
+      "discovered_on": null,
+      "revealed_at": null,
+      "patched_at": null,
+      "reveal_tier": "discovered",
+      "withdrawn": true,
+      "withdrawn_reason": "duplicate"
+    }
+  ]
 }

--- a/scripts/mythos/generate.test.ts
+++ b/scripts/mythos/generate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { renderPost, GenerationError, deriveSlug } from './generate';
+import { renderPost, GenerationError, deriveSlug, buildUserPrompt } from './generate';
 import type { Digest, Trigger } from './types';
+import type { LedgerAggregates } from './ledger';
 
 const oldDigest: Digest = {
   as_of: '2026-05-22T00:00:00Z',
@@ -39,6 +40,37 @@ const triggers: Trigger[] = [
 ];
 
 const allKnownCves = ['CVE-2026-0001', 'CVE-2026-0002'];
+
+// Mirrors the live payload's aggregates so the tests read as the real thing.
+const ledger: LedgerAggregates = {
+  total: 2736,
+  withdrawals: {
+    total: 243,
+    by_reason: {
+      duplicate: 81,
+      false_positive: 11,
+      mistake: 137,
+      out_of_scope: 9,
+      rejected_not_sec: 5,
+    },
+  },
+  funnel: { acknowledged_by_maintainer: 1603, discovered: 434, revealed: 214, sent: 485 },
+  severity_agreement: {
+    rated_pairs: 117,
+    agree: 52,
+    disagree: 65,
+    claude_higher: 55,
+    maintainer_higher: 10,
+    disagree_pct: 55.6,
+  },
+  latency: {
+    discovery_to_reveal: { median_days: 130, sample: 213, excluded_negative: 0 },
+    discovery_to_patch: { median_days: 50, sample: 193, excluded_negative: 18 },
+  },
+};
+
+const ledgerDigest: Digest = { ...newDigest, ledger };
+const padding = 'detail '.repeat(120);
 
 describe('renderPost()', () => {
   beforeEach(() => {
@@ -150,5 +182,126 @@ describe('deriveSlug()', () => {
       },
     ]);
     expect(slug).toBe('2026-05-24-mythos-sunday');
+  });
+});
+
+describe('ledger statistics in generated posts', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function attempt(body: string) {
+    const callLlm = vi.fn().mockResolvedValue(body);
+    const [result] = await Promise.allSettled([
+      renderPost({
+        oldDigest,
+        newDigest: ledgerDigest,
+        triggers,
+        allKnownCves,
+        callLlm,
+      }),
+      vi.runAllTimersAsync(),
+    ]);
+    return result;
+  }
+
+  it('accepts a post that cites ledger figures with their denominators', async () => {
+    const result = await attempt(
+      `wolfSSL CVE-2026-0002 is newly revealed. Mythos has withdrawn 243 of 2736 findings, ` +
+        `137 of 243 of them logged as mistakes. Of the 117 findings rated by both Claude and a ` +
+        `maintainer, the two disagree on 65 of 117 (55.6%). ${padding}.`,
+    );
+    expect(result.status).toBe('fulfilled');
+    const post = (result as PromiseFulfilledResult<{ body: string }>).value;
+    expect(post.body).toContain('65 of 117');
+    expect(post.body).toContain('137 of 243');
+  });
+
+  it('rejects a statistic the payload never produced', async () => {
+    // The payload says 243 withdrawals, not 300.
+    const result = await attempt(
+      `wolfSSL CVE-2026-0002 is newly revealed. Mythos has withdrawn 300 of 2736 findings. ` +
+        `${padding}.`,
+    );
+    expect(result.status).toBe('rejected');
+    expect((result as PromiseRejectedResult).reason).toBeInstanceOf(GenerationError);
+    expect((result as PromiseRejectedResult).reason.message).toContain('300');
+  });
+
+  it('rejects a sparse figure cited without its denominator', async () => {
+    const result = await attempt(
+      `wolfSSL CVE-2026-0002 is newly revealed. Claude and maintainers disagreed on severity ` +
+        `for 65 findings. ${padding}.`,
+    );
+    expect(result.status).toBe('rejected');
+    expect((result as PromiseRejectedResult).reason.message).toContain('denominator');
+  });
+
+  it('rejects a negative duration the aggregates deliberately excluded', async () => {
+    // 18 findings record a patch up to 38 days before discovery; those are
+    // dropped from the median and must not surface as a published figure.
+    const result = await attempt(
+      `wolfSSL CVE-2026-0002 is newly revealed. Some patches landed 38 days before the bug ` +
+        `was discovered. ${padding}.`,
+    );
+    expect(result.status).toBe('rejected');
+    expect((result as PromiseRejectedResult).reason.message).toContain('38');
+  });
+
+  it('names the withdrawal surge in the post description', async () => {
+    const surge: Trigger[] = [
+      ...triggers,
+      {
+        kind: 'withdrawal_surge',
+        delta: 12,
+        total: 243,
+        of_total: 2736,
+        top_reason: 'mistake',
+        top_reason_count: 137,
+      },
+    ];
+    const callLlm = vi
+      .fn()
+      .mockResolvedValue(
+        `wolfSSL CVE-2026-0002 is newly revealed. Mythos withdrew 12 more findings, ` +
+          `243 of 2736 in total. ${padding}.`,
+      );
+    const post = await renderPost({
+      oldDigest,
+      newDigest: ledgerDigest,
+      triggers: surge,
+      allKnownCves,
+      callLlm,
+    });
+    expect(post.frontmatter.triggers).toContain('withdrawal_surge');
+    expect(post.frontmatter.description).toContain('Findings withdrawn.');
+  });
+
+  it('leaves posts without ledger aggregates unconstrained by the new checks', async () => {
+    const callLlm = vi.fn().mockResolvedValue(`wolfSSL CVE-2026-0002 revealed. ${padding}.`);
+    const post = await renderPost({ oldDigest, newDigest, triggers, allKnownCves, callLlm });
+    expect(post.body).toContain('CVE-2026-0002');
+  });
+});
+
+describe('buildUserPrompt()', () => {
+  it('surfaces every ledger aggregate with the denominator it must be cited with', () => {
+    const brief = buildUserPrompt(oldDigest, ledgerDigest, triggers);
+    expect(brief).toContain('243 of 2736 findings');
+    expect(brief).toContain('mistake 137 of 243');
+    expect(brief).toContain('disagree on 65 of 117');
+    expect(brief).toContain('agree on 52 of 117');
+    expect(brief).toContain('130 days over 213 findings');
+    expect(brief).toContain('50 days over 193 findings');
+    // The excluded negatives are disclosed, not silently dropped.
+    expect(brief).toContain('18 further findings were excluded');
+  });
+
+  it('omits the ledger section entirely when the digest carries no aggregates', () => {
+    expect(buildUserPrompt(oldDigest, newDigest, triggers)).not.toContain('Ledger context');
   });
 });

--- a/scripts/mythos/generate.ts
+++ b/scripts/mythos/generate.ts
@@ -1,3 +1,5 @@
+import { missingDenominators, sparseFiguresFor, unsupportedFigures } from './validate';
+import type { LedgerAggregates } from './ledger';
 import type { Digest, Trigger } from './types';
 
 export class GenerationError extends Error {
@@ -43,7 +45,13 @@ You are a security-news tracker, not a hype outlet. Be specific, cite CVE IDs, n
 beyond the data you are given. Output ONLY the body of the post in markdown. No frontmatter. \
 Aim for 120-${MAX_WORDS} words. Lead with the most concrete item (a revealed CVE or new \
 project). End with a single line crediting Anthropic's dashboard at \
-https://red.anthropic.com/2026/cvd/ as the source.`;
+https://red.anthropic.com/2026/cvd/ as the source.
+
+Numbers are checked before publication. Every numeral you write must appear verbatim in \
+the brief below — if a figure is not there, do not state it, and do not compute new ones. \
+Where the brief gives a figure as "N of M", keep the "of M" denominator; those figures come \
+from fields that only a fraction of findings carry, and without the denominator they read as \
+claims about the whole corpus. Write any date in ISO form (YYYY-MM-DD).`;
 
 export type RenderOpts = {
   oldDigest: Digest;
@@ -65,6 +73,7 @@ export async function renderPost(opts: RenderOpts): Promise<Post> {
   const knownSet = new Set(opts.allKnownCves);
 
   const userPrompt = buildUserPrompt(opts.oldDigest, opts.newDigest, opts.triggers);
+  const sparseFigures = opts.newDigest.ledger ? sparseFiguresFor(opts.newDigest.ledger) : [];
 
   let lastDraft = '';
   let lastError = '';
@@ -99,6 +108,21 @@ export async function renderPost(opts: RenderOpts): Promise<Post> {
       lastError = `hallucinated CVEs not present in payload: ${hallucinated.join(', ')}`;
       continue;
     }
+    // Validate against the base prompt, never `userPrompt + corrective`: the
+    // corrective quotes the numbers that were just rejected, and admitting
+    // those would let a bad figure pass on the retry that names it.
+    const unsupported = unsupportedFigures(body, userPrompt);
+    if (unsupported.length > 0) {
+      lastError = `figures not supported by the brief: ${unsupported.join(', ')}`;
+      continue;
+    }
+    const undenominated = missingDenominators(body, sparseFigures);
+    if (undenominated.length > 0) {
+      lastError =
+        `these figures need their denominator: ` +
+        undenominated.map((f) => `${f.value} (${f.label}, of ${f.denominator})`).join('; ');
+      continue;
+    }
 
     return {
       slug: deriveSlug(now, opts.triggers),
@@ -122,17 +146,76 @@ export async function renderPost(opts: RenderOpts): Promise<Post> {
   throw new GenerationError(`generation failed after retry: ${lastError}`, lastDraft);
 }
 
-function buildUserPrompt(oldD: Digest, newD: Digest, triggers: Trigger[]): string {
+export function buildUserPrompt(oldD: Digest, newD: Digest, triggers: Trigger[]): string {
   return [
     `As of ${newD.as_of}, the Mythos dashboard reports:`,
     `- ${newD.headline.disclosed} disclosed (was ${oldD.headline.disclosed})`,
     `- ${newD.headline.acknowledged} acknowledged (was ${oldD.headline.acknowledged})`,
     `- ${newD.headline.fixed} patched (was ${oldD.headline.fixed})`,
     `- ${newD.headline.advisories} CVEs/GHSAs published (was ${oldD.headline.advisories})`,
+    ...(newD.ledger ? ['', ...ledgerBrief(newD.ledger)] : []),
     ``,
     `Today's triggers to cover:`,
     JSON.stringify(triggers, null, 2),
   ].join('\n');
+}
+
+/**
+ * Renders the ledger aggregates as the model is expected to quote them. Every
+ * figure drawn from a sparse field is written "N of M" here so the required
+ * shape is modelled rather than only demanded; `missingDenominators()` then
+ * enforces it on the way out.
+ */
+function ledgerBrief(agg: LedgerAggregates): string[] {
+  const lines = [
+    `Ledger context — every figure below is derived from the payload's ledger of ` +
+      `${agg.total} findings, and several come from fields most findings do not carry:`,
+    `- Withdrawn: ${agg.withdrawals.total} of ${agg.total} findings.` +
+      (agg.withdrawals.total === 0
+        ? ''
+        : ` By reason: ${Object.entries(agg.withdrawals.by_reason)
+            .sort(([, a], [, b]) => b - a)
+            .map(([reason, n]) => `${reason} ${n} of ${agg.withdrawals.total}`)
+            .join(', ')}.`),
+    `- Reveal-tier funnel across all ${agg.total} findings: ${Object.entries(agg.funnel)
+      .map(([tier, n]) => `${tier} ${n}`)
+      .join(', ')}.`,
+  ];
+
+  const sev = agg.severity_agreement;
+  lines.push(
+    sev.rated_pairs === 0
+      ? `- Severity: no finding carries both a Claude and a maintainer rating, so nothing can ` +
+          `be said about how often they agree.`
+      : `- Severity: ${sev.rated_pairs} findings carry both a Claude and a maintainer rating. ` +
+          `The two disagree on ${sev.disagree} of ${sev.rated_pairs} (${sev.disagree_pct}%) and ` +
+          `agree on ${sev.agree} of ${sev.rated_pairs}; Claude rated higher on ` +
+          `${sev.claude_higher} of ${sev.rated_pairs}, the maintainer on ` +
+          `${sev.maintainer_higher} of ${sev.rated_pairs}.`,
+  );
+
+  for (const [label, stat] of [
+    ['discovery to reveal', agg.latency.discovery_to_reveal],
+    ['discovery to patch', agg.latency.discovery_to_patch],
+  ] as const) {
+    if (stat.median_days === null) {
+      lines.push(`- Median ${label}: too few findings carry both dates to state a median.`);
+      continue;
+    }
+    // The excluded negatives are disclosed rather than dropped silently: the
+    // payload's dates are not strictly ordered, and the reader is owed that.
+    const excluded =
+      stat.excluded_negative === 0
+        ? ''
+        : ` ${stat.excluded_negative} further findings were excluded because their recorded ` +
+          `end date precedes their discovery date.`;
+    lines.push(
+      `- Median ${label}: ${stat.median_days} days over ${stat.sample} findings carrying ` +
+        `both dates.${excluded}`,
+    );
+  }
+
+  return lines;
 }
 
 function deriveTitle(triggers: Trigger[]): string {
@@ -153,6 +236,7 @@ function deriveDescription(triggers: Trigger[], newD: Digest): string {
   if (triggers.some((t) => t.kind === 'new_project')) parts.push(`New project added.`);
   if (triggers.some((t) => t.kind === 'bug_class_shift' || t.kind === 'funnel_shift'))
     parts.push(`Funnel or bug-class shift.`);
+  if (triggers.some((t) => t.kind === 'withdrawal_surge')) parts.push(`Findings withdrawn.`);
   parts.push(`${newD.headline.disclosed} total disclosed.`);
   return parts.join(' ');
 }

--- a/scripts/mythos/ledger.test.ts
+++ b/scripts/mythos/ledger.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { aggregateLedger } from './ledger';
+import type { LedgerEntry } from './ledger';
+
+function entry(over: Partial<LedgerEntry> = {}): LedgerEntry {
+  return {
+    claude_severity: null,
+    maintainer_severity: null,
+    discovered_on: null,
+    revealed_at: null,
+    patched_at: null,
+    reveal_tier: 'discovered',
+    withdrawn: false,
+    withdrawn_reason: null,
+    ...over,
+  };
+}
+
+describe('aggregateLedger()', () => {
+  it('counts withdrawals by reason, ignoring reasons on non-withdrawn entries', () => {
+    const agg = aggregateLedger([
+      entry({ withdrawn: true, withdrawn_reason: 'mistake' }),
+      entry({ withdrawn: true, withdrawn_reason: 'mistake' }),
+      entry({ withdrawn: true, withdrawn_reason: 'duplicate' }),
+      entry({ withdrawn: true, withdrawn_reason: null }),
+      // The live payload carries 4 entries with a reason but withdrawn=false;
+      // those are not withdrawals and must not inflate the counts.
+      entry({ withdrawn: false, withdrawn_reason: 'duplicate' }),
+    ]);
+    expect(agg.total).toBe(5);
+    expect(agg.withdrawals.total).toBe(4);
+    expect(agg.withdrawals.by_reason).toEqual({ duplicate: 1, mistake: 2, unspecified: 1 });
+  });
+
+  it('partitions every entry across the reveal_tier funnel', () => {
+    const agg = aggregateLedger([
+      entry({ reveal_tier: 'sent' }),
+      entry({ reveal_tier: 'sent' }),
+      entry({ reveal_tier: 'revealed' }),
+      entry({ reveal_tier: null }),
+    ]);
+    expect(agg.funnel).toEqual({ revealed: 1, sent: 2, unknown: 1 });
+    expect(Object.values(agg.funnel).reduce((a, b) => a + b, 0)).toBe(agg.total);
+  });
+
+  it('counts severity agreement only over pairs rated by both, with a denominator', () => {
+    const agg = aggregateLedger([
+      entry({ claude_severity: 'high', maintainer_severity: 'high' }),
+      entry({ claude_severity: 'high', maintainer_severity: 'medium' }),
+      entry({ claude_severity: 'critical', maintainer_severity: 'low' }),
+      entry({ claude_severity: 'medium', maintainer_severity: 'critical' }),
+      // Unrated by the maintainer — excluded from the denominator entirely.
+      entry({ claude_severity: 'critical', maintainer_severity: null }),
+      entry({ claude_severity: null, maintainer_severity: 'high' }),
+    ]);
+    expect(agg.severity_agreement).toEqual({
+      rated_pairs: 4,
+      agree: 1,
+      disagree: 3,
+      claude_higher: 2,
+      maintainer_higher: 1,
+      disagree_pct: 75,
+    });
+  });
+
+  it('reports zeroed severity agreement rather than dividing by zero', () => {
+    const agg = aggregateLedger([entry({ claude_severity: 'high' })]);
+    expect(agg.severity_agreement.rated_pairs).toBe(0);
+    expect(agg.severity_agreement.disagree_pct).toBe(0);
+  });
+
+  it('excludes negative discovery-to-patch durations from the median and counts them', () => {
+    const agg = aggregateLedger([
+      entry({ discovered_on: '2026-03-01', patched_at: '2026-03-11T00:00:00Z' }), // +10
+      entry({ discovered_on: '2026-03-01', patched_at: '2026-03-21T00:00:00Z' }), // +20
+      entry({ discovered_on: '2026-03-01', patched_at: '2026-03-31T00:00:00Z' }), // +30
+      // Patch dated before discovery: the payload has 18 of these (min -38 days).
+      // Excluded so it can neither be published nor drag the median down.
+      entry({ discovered_on: '2026-03-01', patched_at: '2026-01-21T00:00:00Z' }), // -39
+    ]);
+    expect(agg.latency.discovery_to_patch).toEqual({
+      median_days: 20,
+      sample: 3,
+      excluded_negative: 1,
+    });
+  });
+
+  it('averages the two middle values for an even-sized latency sample', () => {
+    const agg = aggregateLedger([
+      entry({ discovered_on: '2026-03-01', revealed_at: '2026-03-11T00:00:00Z' }), // +10
+      entry({ discovered_on: '2026-03-01', revealed_at: '2026-03-16T00:00:00Z' }), // +15
+    ]);
+    expect(agg.latency.discovery_to_reveal.median_days).toBe(12.5);
+    expect(agg.latency.discovery_to_reveal.sample).toBe(2);
+  });
+
+  it('returns a null median when no entry carries both dates', () => {
+    const agg = aggregateLedger([entry({ discovered_on: '2026-03-01' })]);
+    expect(agg.latency.discovery_to_patch).toEqual({
+      median_days: null,
+      sample: 0,
+      excluded_negative: 0,
+    });
+  });
+});

--- a/scripts/mythos/ledger.ts
+++ b/scripts/mythos/ledger.ts
@@ -1,0 +1,149 @@
+/**
+ * Aggregation over the payload's `ledger[]` array (2,736 entries in the live
+ * payload). Field coverage is sparse and uneven — `reveal_tier` is present on
+ * every entry while `maintainer_severity` is present on ~4% — so every
+ * aggregate derived from a sparse field carries its own denominator. Callers
+ * must render those denominators; `sparseFiguresFor()` in validate.ts turns
+ * that requirement into a check.
+ */
+
+export type LedgerEntry = {
+  claude_severity?: string | null;
+  maintainer_severity?: string | null;
+  discovered_on?: string | null;
+  revealed_at?: string | null;
+  patched_at?: string | null;
+  reveal_tier?: string | null;
+  withdrawn?: boolean | null;
+  withdrawn_reason?: string | null;
+};
+
+export type LatencyStat = {
+  /** Median over non-negative durations only; null when the sample is empty. */
+  median_days: number | null;
+  /** Entries counted in the median — the denominator for `median_days`. */
+  sample: number;
+  /** Entries dropped because the end date precedes the start date. */
+  excluded_negative: number;
+};
+
+export type SeverityAgreement = {
+  /** Entries rated by both Claude and a maintainer — the denominator. */
+  rated_pairs: number;
+  agree: number;
+  disagree: number;
+  claude_higher: number;
+  maintainer_higher: number;
+  /** disagree / rated_pairs as a percentage, to one decimal place. */
+  disagree_pct: number;
+};
+
+export type LedgerAggregates = {
+  total: number;
+  withdrawals: { total: number; by_reason: Record<string, number> };
+  /** reveal_tier -> count. Partitions all `total` entries. */
+  funnel: Record<string, number>;
+  severity_agreement: SeverityAgreement;
+  latency: { discovery_to_reveal: LatencyStat; discovery_to_patch: LatencyStat };
+};
+
+const SEVERITY_RANK: Record<string, number> = { low: 1, medium: 2, high: 3, critical: 4 };
+
+export function aggregateLedger(entries: LedgerEntry[]): LedgerAggregates {
+  return {
+    total: entries.length,
+    withdrawals: withdrawals(entries),
+    funnel: funnel(entries),
+    severity_agreement: severityAgreement(entries),
+    latency: {
+      discovery_to_reveal: latency(entries, 'revealed_at'),
+      discovery_to_patch: latency(entries, 'patched_at'),
+    },
+  };
+}
+
+function withdrawals(entries: LedgerEntry[]): LedgerAggregates['withdrawals'] {
+  // `withdrawn_reason` is populated on 4 live entries whose `withdrawn` is
+  // false; keying off the boolean keeps the reason counts summing to `total`.
+  const withdrawn = entries.filter((e) => e.withdrawn === true);
+  const byReason: Record<string, number> = {};
+  for (const e of withdrawn) {
+    const reason = e.withdrawn_reason ?? 'unspecified';
+    byReason[reason] = (byReason[reason] ?? 0) + 1;
+  }
+  return { total: withdrawn.length, by_reason: sortKeys(byReason) };
+}
+
+function funnel(entries: LedgerEntry[]): Record<string, number> {
+  const tiers: Record<string, number> = {};
+  for (const e of entries) {
+    const tier = e.reveal_tier ?? 'unknown';
+    tiers[tier] = (tiers[tier] ?? 0) + 1;
+  }
+  return sortKeys(tiers);
+}
+
+function severityAgreement(entries: LedgerEntry[]): SeverityAgreement {
+  let agree = 0;
+  let claudeHigher = 0;
+  let maintainerHigher = 0;
+  for (const e of entries) {
+    const claude = SEVERITY_RANK[e.claude_severity ?? ''];
+    const maintainer = SEVERITY_RANK[e.maintainer_severity ?? ''];
+    if (claude === undefined || maintainer === undefined) continue;
+    if (claude === maintainer) agree++;
+    else if (claude > maintainer) claudeHigher++;
+    else maintainerHigher++;
+  }
+  const disagree = claudeHigher + maintainerHigher;
+  const ratedPairs = agree + disagree;
+  return {
+    rated_pairs: ratedPairs,
+    agree,
+    disagree,
+    claude_higher: claudeHigher,
+    maintainer_higher: maintainerHigher,
+    disagree_pct: ratedPairs === 0 ? 0 : round1((disagree / ratedPairs) * 100),
+  };
+}
+
+function latency(entries: LedgerEntry[], endField: 'revealed_at' | 'patched_at'): LatencyStat {
+  const durations: number[] = [];
+  let excludedNegative = 0;
+  for (const e of entries) {
+    const start = Date.parse(e.discovered_on ?? '');
+    const end = Date.parse(e[endField] ?? '');
+    if (Number.isNaN(start) || Number.isNaN(end)) continue;
+    const days = Math.round((end - start) / 86_400_000);
+    // The live payload's dates are not strictly ordered: 18 entries patch
+    // before they are discovered (min -38 days). A negative duration is not
+    // publishable and must not shift the median, so drop it and report how
+    // many were dropped.
+    if (days < 0) {
+      excludedNegative++;
+      continue;
+    }
+    durations.push(days);
+  }
+  durations.sort((a, b) => a - b);
+  return {
+    median_days: median(durations),
+    sample: durations.length,
+    excluded_negative: excludedNegative,
+  };
+}
+
+function median(sorted: number[]): number | null {
+  if (sorted.length === 0) return null;
+  const mid = sorted.length / 2;
+  if (sorted.length % 2 === 1) return sorted[Math.floor(mid)];
+  return round1((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function sortKeys(counts: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+}

--- a/scripts/mythos/triggers.test.ts
+++ b/scripts/mythos/triggers.test.ts
@@ -104,4 +104,38 @@ describe('triggersFor()', () => {
       bug_class: 'xss',
     });
   });
+  it('detects a withdrawal surge and carries its denominator', () => {
+    const ts = triggersFor(loadDigest('old'), loadDigest('new'), loadRaw('new'));
+    const surges = ts.filter((t) => t.kind === 'withdrawal_surge');
+    expect(surges).toHaveLength(1);
+    expect(surges[0]).toMatchObject({
+      kind: 'withdrawal_surge',
+      delta: 6,
+      total: 8,
+      of_total: 16,
+      top_reason: 'mistake',
+      top_reason_count: 5,
+    });
+  });
+
+  it('ignores a withdrawal delta below the threshold', () => {
+    const o = loadDigest('new');
+    const n: Digest = {
+      ...o,
+      ledger: {
+        ...o.ledger!,
+        withdrawals: { ...o.ledger!.withdrawals, total: o.ledger!.withdrawals.total + 1 },
+      },
+    };
+    expect(triggersFor(o, n).filter((t) => t.kind === 'withdrawal_surge')).toEqual([]);
+  });
+
+  it('skips the withdrawal trigger when the previous snapshot predates ledger aggregation', () => {
+    // The snapshot on main was written before digest() read the ledger.
+    const legacy: Digest = { ...loadDigest('old') };
+    delete legacy.ledger;
+    const ts = triggersFor(legacy, loadDigest('new'), loadRaw('new'));
+    expect(ts.filter((t) => t.kind === 'withdrawal_surge')).toEqual([]);
+    expect(ts.filter((t) => t.kind === 'revealed')).toHaveLength(1);
+  });
 });

--- a/scripts/mythos/triggers.ts
+++ b/scripts/mythos/triggers.ts
@@ -3,6 +3,7 @@ import type { Digest, Trigger } from './types';
 export const BUG_CLASS_MIN_DELTA = 5;
 export const BUG_CLASS_MIN_PCT = 25;
 export const FUNNEL_MIN_PCT = 5;
+export const WITHDRAWAL_MIN_DELTA = 5;
 
 // Shape of the raw payload fields we need for enrichment. Matches the real
 // red.anthropic.com payload: cve_records[].identifier + findings[0] with
@@ -78,6 +79,28 @@ export function triggersFor(oldD: Digest, newD: Digest, newRaw?: RawForEnrichmen
     const pct = Math.abs(((to - from) / from) * 100);
     if (pct < FUNNEL_MIN_PCT) continue;
     triggers.push({ kind: 'funnel_shift', metric, from, to, pct_change: pct });
+  }
+
+  const oldLedger = oldD.ledger;
+  const newLedger = newD.ledger;
+  // Both sides need aggregates: a snapshot written before ledger support has
+  // none, and treating its absence as zero would report every withdrawal ever
+  // recorded as today's surge.
+  if (oldLedger && newLedger) {
+    const delta = newLedger.withdrawals.total - oldLedger.withdrawals.total;
+    if (delta >= WITHDRAWAL_MIN_DELTA) {
+      const [topReason, topCount] = Object.entries(newLedger.withdrawals.by_reason).sort(
+        ([, a], [, b]) => b - a,
+      )[0] ?? ['unspecified', 0];
+      triggers.push({
+        kind: 'withdrawal_surge',
+        delta,
+        total: newLedger.withdrawals.total,
+        of_total: newLedger.total,
+        top_reason: topReason,
+        top_reason_count: topCount,
+      });
+    }
   }
 
   return triggers;

--- a/scripts/mythos/types.ts
+++ b/scripts/mythos/types.ts
@@ -1,3 +1,5 @@
+import type { LedgerAggregates } from './ledger';
+
 export type SeverityBucket = {
   critical: number;
   high: number;
@@ -27,6 +29,11 @@ export type Digest = {
   by_ecosystem: Record<string, SeverityBucket>;
   project_names: string[];
   revealed_cve_ids: string[];
+  /**
+   * Aggregates over the payload's `ledger[]`. Optional because snapshots
+   * written before ledger support have no such block; readers must guard.
+   */
+  ledger?: LedgerAggregates;
 };
 
 export type Trigger =
@@ -39,4 +46,13 @@ export type Trigger =
       from: number;
       to: number;
       pct_change: number;
+    }
+  | {
+      kind: 'withdrawal_surge';
+      delta: number;
+      total: number;
+      /** Ledger entries the `total` is drawn from. */
+      of_total: number;
+      top_reason: string;
+      top_reason_count: number;
     };

--- a/scripts/mythos/validate.test.ts
+++ b/scripts/mythos/validate.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { figuresIn, missingDenominators, sparseFiguresFor, unsupportedFigures } from './validate';
+import { aggregateLedger } from './ledger';
+
+const brief = [
+  'As of 2026-08-26T18:55:53.809770Z, the dashboard reports:',
+  '- 2300 disclosed (was 2290)',
+  '- Withdrawn: 243 of 2736 findings.',
+  '- Of the 117 findings rated by both, they disagree on 65 (55.6%).',
+].join('\n');
+
+describe('figuresIn()', () => {
+  it('ignores digits inside identifiers, URLs, ISO dates and list markers', () => {
+    const body = [
+      'CVE-2026-12340 and GHSA-abcd-1234-wxyz landed.',
+      '1. First item',
+      '2) Second item',
+      'Source: https://red.anthropic.com/2026/cvd/',
+      'Published 2026-08-26.',
+    ].join('\n');
+    expect(figuresIn(body)).toEqual([]);
+  });
+
+  it('normalises thousands separators and percent signs', () => {
+    expect(figuresIn('2,736 findings, 55.6% of them')).toEqual([2736, 55.6]);
+  });
+});
+
+describe('unsupportedFigures()', () => {
+  it('accepts a post whose every figure appears in the brief', () => {
+    const body = '243 of 2736 findings were withdrawn; 65 of 117 rated pairs disagree.';
+    expect(unsupportedFigures(body, brief)).toEqual([]);
+  });
+
+  it('rejects a figure the brief never stated', () => {
+    // 300 is a plausible-looking withdrawal count. The payload says 243.
+    const body = '300 of 2736 findings were withdrawn.';
+    expect(unsupportedFigures(body, brief)).toEqual([300]);
+  });
+
+  it('accepts the rounded and truncated forms of a decimal in the brief', () => {
+    expect(unsupportedFigures('disagreement runs at 56%', brief)).toEqual([]);
+    expect(unsupportedFigures('disagreement runs at 55%', brief)).toEqual([]);
+    expect(unsupportedFigures('disagreement runs at 57%', brief)).toEqual([57]);
+  });
+});
+
+describe('sparseFiguresFor()', () => {
+  const agg = aggregateLedger([
+    { claude_severity: 'high', maintainer_severity: 'medium', reveal_tier: 'revealed' },
+    { claude_severity: 'high', maintainer_severity: 'high', reveal_tier: 'sent' },
+    { withdrawn: true, withdrawn_reason: 'mistake', reveal_tier: 'sent' },
+    { discovered_on: '2026-03-01', patched_at: '2026-03-11T00:00:00Z', reveal_tier: 'sent' },
+  ]);
+
+  it('pairs each sparse-field aggregate with the denominator it must be cited with', () => {
+    const pairs = sparseFiguresFor(agg);
+    expect(pairs).toContainEqual({ label: 'severity disagreements', value: 1, denominator: 2 });
+    expect(pairs).toContainEqual({
+      label: 'withdrawals for reason "mistake"',
+      value: 1,
+      denominator: 1,
+    });
+    expect(pairs).toContainEqual({
+      label: 'median days from discovery to patch',
+      value: 10,
+      denominator: 1,
+    });
+    // A null median is not a figure a post can cite, so it is not listed.
+    expect(pairs.some((p) => p.label.includes('reveal'))).toBe(false);
+  });
+});
+
+describe('missingDenominators()', () => {
+  const sparse = [{ label: 'severity disagreements', value: 65, denominator: 117 }];
+
+  it('flags a sparse figure cited without its denominator', () => {
+    expect(missingDenominators('Claude and maintainers disagreed on 65 findings.', sparse)).toEqual(
+      sparse,
+    );
+  });
+
+  it('passes when the denominator is present', () => {
+    expect(missingDenominators('65 of the 117 rated pairs disagreed.', sparse)).toEqual([]);
+  });
+
+  it('ignores sparse figures the post never cites', () => {
+    expect(missingDenominators('Nothing numeric to see here.', sparse)).toEqual([]);
+  });
+});

--- a/scripts/mythos/validate.ts
+++ b/scripts/mythos/validate.ts
@@ -1,0 +1,100 @@
+import type { LedgerAggregates } from './ledger';
+
+/**
+ * Numeric guardrails for generated posts.
+ *
+ * The pre-existing CVE checks work because identifiers are a closed set of
+ * distinctive tokens. Statistics are not, so the same guarantee is rebuilt
+ * here as a whitelist: every numeral a post states must already appear in the
+ * brief it was given, and the brief is rendered from the digest, which is
+ * computed from the payload. A number the payload never produced cannot reach
+ * a published post.
+ *
+ * Digits that are not statistical claims — identifiers, URLs, ISO dates and
+ * markdown list markers — are stripped before extraction so they neither
+ * trigger a false rejection nor silently widen the whitelist.
+ */
+
+const IDENTIFIER = /\b(?:CVE-\d{4}-\d{4,7}|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})\b/gi;
+const URL = /https?:\/\/\S+/g;
+const ISO_DATE = /\d{4}-\d{2}-\d{2}(?:[T ][\d:.]+Z?)?/g;
+const ORDERED_LIST_MARKER = /^[ \t]{0,3}\d+[.)][ \t]/gm;
+const NUMBER = /\d[\d,]*(?:\.\d+)?/g;
+
+/** A statistic that is only defensible alongside the denominator it came from. */
+export type SparseFigure = { label: string; value: number; denominator: number };
+
+/** Every numeral `text` asserts, in order of appearance, deduplicated. */
+export function figuresIn(text: string): number[] {
+  const stripped = text
+    .replace(IDENTIFIER, ' ')
+    .replace(URL, ' ')
+    .replace(ISO_DATE, ' ')
+    .replace(ORDERED_LIST_MARKER, ' ');
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const match of stripped.match(NUMBER) ?? []) {
+    const n = Number(match.replace(/,/g, ''));
+    if (Number.isNaN(n) || seen.has(n)) continue;
+    seen.add(n);
+    out.push(n);
+  }
+  return out;
+}
+
+/** Figures the post states that the brief never supplied. */
+export function unsupportedFigures(body: string, brief: string): number[] {
+  const allowed = new Set<number>();
+  for (const n of figuresIn(brief)) {
+    // A post may legitimately render "55.6%" as "56%" or "55%"; anything
+    // further from the source figure is a claim the brief does not support.
+    allowed.add(n);
+    allowed.add(Math.round(n));
+    allowed.add(Math.trunc(n));
+  }
+  return figuresIn(body).filter((n) => !allowed.has(n));
+}
+
+/** Sparse figures the post cites without also citing their denominator. */
+export function missingDenominators(body: string, sparse: SparseFigure[]): SparseFigure[] {
+  const stated = new Set(figuresIn(body));
+  return sparse.filter((f) => stated.has(f.value) && !stated.has(f.denominator));
+}
+
+/**
+ * Every ledger aggregate whose meaning depends on a denominator, paired with
+ * it. `maintainer_severity` covers 117 of 2,736 live entries and the latency
+ * fields barely more, so "65 disagreements" without "of 117 rated pairs"
+ * reads as a claim about the whole corpus.
+ */
+export function sparseFiguresFor(agg: LedgerAggregates): SparseFigure[] {
+  const figures: SparseFigure[] = [];
+  const push = (label: string, value: number | null, denominator: number): void => {
+    if (value === null || value === 0 || denominator === 0) return;
+    figures.push({ label, value, denominator });
+  };
+
+  const sev = agg.severity_agreement;
+  push('severity disagreements', sev.disagree, sev.rated_pairs);
+  push('severity agreements', sev.agree, sev.rated_pairs);
+  push('findings Claude rated higher', sev.claude_higher, sev.rated_pairs);
+  push('findings the maintainer rated higher', sev.maintainer_higher, sev.rated_pairs);
+  push('severity disagreement rate', sev.disagree_pct, sev.rated_pairs);
+
+  for (const [reason, count] of Object.entries(agg.withdrawals.by_reason)) {
+    push(`withdrawals for reason "${reason}"`, count, agg.withdrawals.total);
+  }
+
+  push(
+    'median days from discovery to reveal',
+    agg.latency.discovery_to_reveal.median_days,
+    agg.latency.discovery_to_reveal.sample,
+  );
+  push(
+    'median days from discovery to patch',
+    agg.latency.discovery_to_patch.median_days,
+    agg.latency.discovery_to_patch.sample,
+  );
+
+  return figures;
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,7 +20,9 @@ const mythos = defineCollection({
     title: z.string(),
     description: z.string(),
     pubDate: z.coerce.date(),
-    triggers: z.array(z.enum(['revealed', 'new_project', 'bug_class_shift', 'funnel_shift'])),
+    triggers: z.array(
+      z.enum(['revealed', 'new_project', 'bug_class_shift', 'funnel_shift', 'withdrawal_surge']),
+    ),
     cve_ids: z.array(z.string()).default([]),
     projects: z.array(z.string()).default([]),
     headline_snapshot: z.object({


### PR DESCRIPTION
Closes #217.

The tracker read roughly 4% of the payload — identifiers and headline counters. `ledger[]`'s 2,736 entries carry each finding's lifecycle plus three independent severity ratings, and none of it reached the reader.

## The hard part first: how a statistic gets verified

Adding numbers to the brief gives the model many new ways to be confidently wrong on a public security page, and the pipeline previously validated only CVE identifiers. Three checks, designed before deciding which statistics to expose:

**1. Numeric whitelist** (`validate.ts`). Every numeral a post states must appear verbatim in the brief. The brief is rendered from the digest; the digest is computed from the payload. A number the payload never produced cannot reach a published post. Identifiers, URLs, ISO dates and markdown list markers are stripped before extraction so they neither cause a false rejection nor silently widen the whitelist. Rounded and truncated forms of a decimal are accepted (`55.6` → `56` or `55`); anything further is not.

Validation runs against the *base* brief, never `userPrompt + corrective` — the corrective quotes the numbers just rejected, and admitting those would let a bad figure pass on the very retry that names it.

**2. Mandatory denominators.** `maintainer_severity` is present on 117 of 2,736 entries; the latency fields barely more. Every sparse aggregate is paired with its denominator, and a post citing the numerator without it is rejected. The brief renders these as `"N of M"` so the required shape is modelled, not merely demanded.

**3. Negative durations.** 18 live findings record a patch before their discovery (min −38 days). Those are excluded from the median, counted, and disclosed in the brief — not dropped silently.

## What the ledger now yields

`digest()` emits withdrawals by reason, the `reveal_tier` funnel, severity agreement with its denominator, and both discovery latencies. A `withdrawal_surge` trigger fires when withdrawals jump by ≥5; `src/content.config.ts` widens the frontmatter enum in the same change, or the build fails against posts already on `main`.

`Digest.ledger` is optional: the snapshot on `main` was written before ledger support, and `triggersFor()` requires aggregates on *both* sides — treating absence as zero would report every withdrawal ever recorded as today's surge.

## Test output

```
npm run format:check   All matched files use Prettier code style!
npm run lint           clean
npm run typecheck      Result (128 files): 0 errors, 0 warnings, 1 hint
npm test               Test Files 32 passed (32) | Tests 266 passed (266)
npm run build          17 page(s) built — Complete!
```

New tests: 7 in `ledger.test.ts`, 9 in `validate.test.ts`, 3 in `digest.test.ts`, 3 in `triggers.test.ts`, 7 in `generate.test.ts`. The ones that carry the acceptance criteria:

- `rejects a statistic the payload never produced` — body claims 300 withdrawals against a payload of 243; generation fails.
- `rejects a sparse figure cited without its denominator` — body cites 65 disagreements without "of 117".
- `rejects a negative duration the aggregates deliberately excluded` — body publishes the −38-day patch lag.
- `excludes negative discovery-to-patch durations from the median and counts them`.
- `skips the withdrawal trigger when the previous snapshot predates ledger aggregation`.

## End-to-end against the live payload

Real payload, real CLI, full validation loop. Triggers `revealed` + `withdrawal_surge` fired, and the post passed every check citing:

> The ledger recorded 12 new withdrawals, bringing the running total to **243 of 2736** findings. The breakdown by reason: mistake **137 of 243**, duplicate **81 of 243** […] Claude rated higher than the maintainer on **55 of 117**; the two agreed on **52 of 117**. Median time from discovery to patch is **50 days over 193 findings** carrying both dates.

Out of scope, per the issue: #216 (chronological backfill) and #138 (history.jsonl timeline).

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
