### PR TITLE
fix(mythos): normalize generated post bodies with prettier on write

### DIFF
--- a/scripts/mythos/backfill.test.ts
+++ b/scripts/mythos/backfill.test.ts
@@ -8,7 +8,6 @@ import {
   headlineAsOf,
   lastHeadlineDay,
   partitionByRevealDate,
-  prettyBody,
   previousDay,
   type BackfillPayload,
 } from './backfill';
@@ -228,17 +227,6 @@ describe('eventGuidance()', () => {
     const guidance = eventGuidance(event);
     expect(guidance).toMatch(/Open with two or three sentences/);
     expect(guidance).toMatch(/Close with two or three sentences/);
-  });
-});
-
-describe('prettyBody()', () => {
-  it('rewrites emphasis the model varies on, so the post survives format:check', async () => {
-    expect(await prettyBody('*Source: dashboard*')).toBe('_Source: dashboard_');
-  });
-
-  it('leaves an already-clean body alone', async () => {
-    const clean = 'Ten identifiers landed.\n\n_Backfilled: reconstructed from the payload._';
-    expect(await prettyBody(clean)).toBe(clean);
   });
 });
 

--- a/scripts/mythos/backfill.ts
+++ b/scripts/mythos/backfill.ts
@@ -36,7 +36,7 @@ import type { RawPayload, RevealRecord } from './digest';
 import { triggersFor } from './triggers';
 import { renderPost } from './generate';
 import { claudeCliCallLlm, type CallLlm } from './llm';
-import { writePost } from './write';
+import { prettyBody, writePost } from './write';
 import type { Digest, Trigger } from './types';
 
 const PAYLOAD_URL = 'https://red.anthropic.com/2026/cvd/data/payload.json';
@@ -294,18 +294,6 @@ export function eventScopedLlm(base: CallLlm, event: RevealEvent): CallLlm {
   };
 }
 
-/**
- * Normalize a generated body to prettier's own output. The model emits
- * `*emphasis*` some runs and `_emphasis_` others; prettier rewrites the first
- * form, so an unnormalized post fails format:check in CI and blocks the PR —
- * the same class of failure #214 fixed for generated frontmatter.
- */
-export async function prettyBody(body: string): Promise<string> {
-  const prettier = await import('prettier');
-  const config = await prettier.resolveConfig(join(POSTS_DIR, 'post.md'));
-  return (await prettier.format(body, { ...config, parser: 'markdown' })).trimEnd();
-}
-
 function summarize(event: RevealEvent): string {
   const projects = new Map<string, number>();
   const classes = new Map<string, number>();
@@ -390,7 +378,7 @@ async function main(): Promise<void> {
       console.log(post.body);
       continue;
     }
-    writePost({ post, postsDir: POSTS_DIR });
+    await writePost({ post, postsDir: POSTS_DIR });
     console.log(
       `[backfill] wrote ${post.slug}.md (${post.frontmatter.cve_ids.length} identifiers)`,
     );

--- a/scripts/mythos/run.ts
+++ b/scripts/mythos/run.ts
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
   if (isBootstrap) {
     console.log(`[mythos] bootstrap: writing placeholder post + snapshot`);
     if (!DRY_RUN) {
-      writePostAndSnapshot({
+      await writePostAndSnapshot({
         post: bootstrapPost(),
         digest: newDigest,
         postsDir: POSTS_DIR,
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  writePostAndSnapshot({
+  await writePostAndSnapshot({
     post,
     digest: newDigest,
     postsDir: POSTS_DIR,

--- a/scripts/mythos/write.test.ts
+++ b/scripts/mythos/write.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writePost, writePostAndSnapshot } from './write';
+import { prettyBody, writePost, writePostAndSnapshot } from './write';
 import type { Digest } from './types';
 import type { Post } from './generate';
 
@@ -49,8 +49,8 @@ describe('mythos post writer', () => {
     revealed_cve_ids: ['CVE-2026-0001', 'CVE-2026-0002'],
   };
 
-  it('writes a valid frontmatter markdown post and the snapshot JSON', () => {
-    writePostAndSnapshot({
+  it('writes a valid frontmatter markdown post and the snapshot JSON', async () => {
+    await writePostAndSnapshot({
       post,
       digest,
       postsDir: join(dir, 'src/content/mythos'),
@@ -71,11 +71,11 @@ describe('mythos post writer', () => {
     expect(snap.revealed_cve_ids).toEqual(['CVE-2026-0001', 'CVE-2026-0002']);
   });
 
-  it('writePost() leaves the snapshot alone', () => {
+  it('writePost() leaves the snapshot alone', async () => {
     // The backfill backdates ten posts against a snapshot that must stay put:
     // it is the forward-only live path's record of "latest state seen", and
     // moving it would make the next scheduled run regenerate or skip.
-    writePost({ post, postsDir: join(dir, 'src/content/mythos') });
+    await writePost({ post, postsDir: join(dir, 'src/content/mythos') });
 
     expect(existsSync(join(dir, 'src/content/mythos/2026-05-24-wolfssl-cve-2026-0002.md'))).toBe(
       true,
@@ -83,8 +83,8 @@ describe('mythos post writer', () => {
     expect(existsSync(join(dir, 'src/content/mythos/_data/snapshot.json'))).toBe(false);
   });
 
-  it('writePost() marks a backfilled post in its frontmatter', () => {
-    writePost({
+  it('writePost() marks a backfilled post in its frontmatter', async () => {
+    await writePost({
       post: { ...post, frontmatter: { ...post.frontmatter, backfilled: true } },
       postsDir: join(dir, 'src/content/mythos'),
     });
@@ -95,8 +95,8 @@ describe('mythos post writer', () => {
     expect(md).toContain('backfilled: true');
   });
 
-  it('omits the backfilled key on live posts', () => {
-    writePost({ post, postsDir: join(dir, 'src/content/mythos') });
+  it('omits the backfilled key on live posts', async () => {
+    await writePost({ post, postsDir: join(dir, 'src/content/mythos') });
     const md = readFileSync(
       join(dir, 'src/content/mythos/2026-05-24-wolfssl-cve-2026-0002.md'),
       'utf8',
@@ -116,7 +116,7 @@ describe('mythos post writer', () => {
         projects: Array.from({ length: 112 }, (_, i) => `org-${i}/project-${i}`),
       },
     };
-    writePostAndSnapshot({
+    await writePostAndSnapshot({
       post: many,
       digest,
       postsDir: join(dir, 'src/content/mythos'),
@@ -128,5 +128,42 @@ describe('mythos post writer', () => {
     const config = await prettier.resolveConfig('post.md');
     const formatted = await prettier.format(written, { ...config, parser: 'markdown' });
     expect(formatted).toBe(written);
+  });
+
+  it('normalizes emphasis the model varies on, so the live post survives format:check', async () => {
+    // run.ts writes whatever the model returned. Some runs it closes on
+    // `*Source: ...*`, which prettier rewrites to `_`, failing format:check and
+    // blocking the tracker's own auto-merge PR for a reason unrelated to the
+    // content. Normalize deterministically on the way to disk instead.
+    await writePost({
+      post: { ...post, body: 'Ten identifiers landed.\n\n*Source: Mythos CVD dashboard.*' },
+      postsDir: join(dir, 'src/content/mythos'),
+    });
+    const md = readFileSync(join(dir, `src/content/mythos/${post.slug}.md`), 'utf8');
+    expect(md).toContain('_Source: Mythos CVD dashboard._');
+    expect(md).not.toContain('*Source:');
+
+    const prettier = await import('prettier');
+    const config = await prettier.resolveConfig('post.md');
+    expect(await prettier.format(md, { ...config, parser: 'markdown' })).toBe(md);
+  });
+
+  it('writes an already-clean body byte-identical', async () => {
+    const clean = 'Ten identifiers landed.\n\n_Source: Mythos CVD dashboard._';
+    await writePost({ post: { ...post, body: clean }, postsDir: join(dir, 'src/content/mythos') });
+    const md = readFileSync(join(dir, `src/content/mythos/${post.slug}.md`), 'utf8');
+    const sep = '\n---\n\n';
+    expect(md.slice(md.indexOf(sep) + sep.length)).toBe(`${clean}\n`);
+  });
+
+  describe('prettyBody()', () => {
+    it('rewrites emphasis the model varies on', async () => {
+      expect(await prettyBody('*Source: dashboard*')).toBe('_Source: dashboard_');
+    });
+
+    it('leaves an already-clean body alone', async () => {
+      const clean = 'Ten identifiers landed.\n\n_Backfilled: reconstructed from the payload._';
+      expect(await prettyBody(clean)).toBe(clean);
+    });
   });
 });

--- a/scripts/mythos/write.ts
+++ b/scripts/mythos/write.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import type { Digest } from './types';
 import type { Post } from './generate';
@@ -16,24 +17,54 @@ export type WritePostOpts = {
 };
 
 /**
+ * Anchors prettier config resolution inside the repo, not in `postsDir` — the
+ * latter is a scratch directory under test, where the repo's .prettierrc is
+ * not on the lookup path and the formatting would silently diverge from CI's.
+ */
+const CONFIG_ANCHOR = join(dirname(fileURLToPath(import.meta.url)), 'post.md');
+
+/**
+ * Normalize a generated body to prettier's own output. The model emits
+ * `*emphasis*` some runs and `_emphasis_` others; prettier rewrites the first
+ * form, so an unnormalized post fails format:check in CI and blocks the
+ * tracker's own PR — the same class of failure #214 fixed for generated
+ * frontmatter.
+ *
+ * Delimiter and whitespace normalization only: it runs after renderPost()'s
+ * validation, on the way to disk, and never adds or removes an identifier or
+ * a figure. It is not a way to launder a body past those checks.
+ */
+export async function prettyBody(body: string): Promise<string> {
+  const prettier = await import('prettier');
+  const config = await prettier.resolveConfig(CONFIG_ANCHOR);
+  return (await prettier.format(body, { ...config, parser: 'markdown' })).trimEnd();
+}
+
+/**
  * Post only, deliberately no snapshot. snapshot.json is the forward-only live
  * path's record of "latest state seen"; the backfill writes ten backdated
  * posts, and advancing (or rewinding) the snapshot for any of them would make
  * the next scheduled run regenerate or skip — a break that would not surface
  * until the next real trigger day.
  */
-export function writePost({ post, postsDir }: WritePostOpts): void {
+export async function writePost({ post, postsDir }: WritePostOpts): Promise<void> {
+  const body = await prettyBody(post.body);
   mkdirSync(postsDir, { recursive: true });
-  writeFileSync(join(postsDir, `${post.slug}.md`), renderMarkdown(post), 'utf8');
+  writeFileSync(join(postsDir, `${post.slug}.md`), renderMarkdown(post, body), 'utf8');
 }
 
-export function writePostAndSnapshot({ post, digest, postsDir, snapshotPath }: WriteOpts): void {
-  writePost({ post, postsDir });
+export async function writePostAndSnapshot({
+  post,
+  digest,
+  postsDir,
+  snapshotPath,
+}: WriteOpts): Promise<void> {
+  await writePost({ post, postsDir });
   mkdirSync(dirname(snapshotPath), { recursive: true });
   writeFileSync(snapshotPath, JSON.stringify(digest, null, 2) + '\n', 'utf8');
 }
 
-function renderMarkdown(post: Post): string {
+function renderMarkdown(post: Post, body: string): string {
   const fm = post.frontmatter;
   const yaml = [
     `title: ${yamlString(fm.title)}`,
@@ -49,7 +80,7 @@ function renderMarkdown(post: Post): string {
     `  fixed: ${fm.headline_snapshot.fixed}`,
     `  advisories: ${fm.headline_snapshot.advisories}`,
   ].join('\n');
-  return `---\n${yaml}\n---\n\n${post.body}\n`;
+  return `---\n${yaml}\n---\n\n${body}\n`;
 }
 
 /**


### PR DESCRIPTION
Closes #221.

## What

`scripts/mythos/run.ts` wrote whatever the model returned straight to disk. On any run where the model picks `*emphasis*` over `_emphasis_`, prettier rewrites the file and `format:check` fails in CI — blocking the tracker's own auto-merge PR for a reason unrelated to the content. #214 fixed this class of failure for generated *frontmatter*; #220 fixed the *body* for the backfill only and deliberately left the live path alone to stay in scope.

`prettyBody()` moves out of `backfill.ts` into `write.ts` and is called from `writePost()`, so both paths share one formatter (acceptance 3). It runs **after** `renderPost()`'s validation, on the way to disk — delimiter and whitespace normalization only, never adding or removing an identifier or figure, so it cannot launder a body past the word-count, required-identifier, hallucinated-identifier, or figure-whitelist checks.

`writePost`/`writePostAndSnapshot` are now async; both callers (`run.ts` bootstrap + main write sites, `backfill.ts`) await them. `snapshot.json` is untouched — `writePost()` still deliberately writes no snapshot.

One deviation from the reference implementation: config resolution is anchored to the module's own directory rather than `postsDir`. Under test `postsDir` is a scratch dir where the repo `.prettierrc` is not on the lookup path, so the formatting would silently diverge from CI's.

## Failing-test-first evidence

With `writePost()` reverted to writing `post.body` unformatted, the new test fails for the right reason:

```
× normalizes emphasis the model varies on, so the live post survives format:check 5ms
AssertionError: expected '---\ntitle: \'wolfSSL CVE-2026-0002: …' to contain '_Source: Mythos CVD dashboard._'
      Tests  1 failed | 8 skipped (9)
```

## Test output

Mythos suites:

```
 Test Files  9 passed (9)
      Tests  90 passed (90)
```

Full gate suite, all five green:

```
$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ npm run lint
> eslint .
(no output, exit 0)

$ npm run typecheck
Result (130 files):
- 0 errors
- 0 warnings
- 1 hint

$ npm test
 Test Files  33 passed (33)
      Tests  294 passed (294)

$ npm run build
[build] 26 page(s) built in 2.24s
[build] Complete!
```

## Coverage added

In `scripts/mythos/write.test.ts`, next to the code under test (acceptance 4):

- `*emphasis*` body → written as `_emphasis_`, and the written file is asserted prettier-clean end to end (acceptance 1)
- already-clean body → the body region on disk is byte-identical, no trailing-newline churn (acceptance 2)
- `prettyBody()` unit tests (rewrite + already-clean no-op) moved over from `backfill.test.ts`

## Note on #223

Rebased check: `main` is still at 92f4ac9, so #223 had not landed. If it lands first it will need `await` on its `writePostAndSnapshot` call site in `run.ts` — the signature is now `Promise<void>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)