### PR TITLE
fix(blog): pin every date formatter to UTC

### DIFF
--- a/src/components/mythos/Timeline.tsx
+++ b/src/components/mythos/Timeline.tsx
@@ -41,7 +41,13 @@ const PAD = { top: 16, right: 16, bottom: 28, left: 44 };
 const HEIGHT = 280;
 const LAG_HEIGHT = 56;
 
-const dateFmt = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+// history rows are bare YYYY-MM-DD dates parsed as UTC midnight, and this axis
+// renders in the viewer's browser — pin the zone so the labels match the data.
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  timeZone: 'UTC',
+});
 
 export default function Timeline({ history }: Props) {
   const [view, setView] = useState<View>('funnel');

--- a/src/components/os/apps/BlogApp.test.tsx
+++ b/src/components/os/apps/BlogApp.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+// UTC midnight is what z.coerce.date() produces from a bare YYYY-MM-DD
+// frontmatter date — the one value that lands on the previous day in every
+// western zone, and on the same day everywhere east of Greenwich.
+const PUB_DATE = '2026-04-16T00:00:00.000Z';
+
+const PAYLOAD = {
+  posts: [
+    {
+      slug: 'boundary-post',
+      title: 'Boundary post',
+      description: 'Published at UTC midnight.',
+      pubDate: PUB_DATE,
+      updatedDate: null,
+      tags: [],
+    },
+  ],
+  fetchedAt: PUB_DATE,
+};
+
+const ORIGINAL_TZ = process.env.TZ;
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+/**
+ * The formatter is module-level, so the zone is bound at import time —
+ * resetModules() is what makes each zone a genuinely fresh construction.
+ */
+async function renderInZone(tz: string) {
+  process.env.TZ = tz;
+  vi.resetModules();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, json: async () => structuredClone(PAYLOAD) }),
+  );
+  const { default: BlogApp } = await import('./BlogApp');
+  render(<BlogApp />);
+  return screen.findByText(/2026$/);
+}
+
+describe('BlogApp post dates', () => {
+  // This renders in the viewer's browser, so an unpinned formatter shows a
+  // reader in Los Angeles a different day than one in Berlin for the same post.
+  it.each(['America/Los_Angeles', 'UTC', 'Asia/Tokyo'])(
+    'renders the post date as its UTC calendar date in %s',
+    async (tz) => {
+      const date = await renderInZone(tz);
+      expect(date.textContent).toBe('Apr 16, 2026');
+    },
+  );
+});

--- a/src/components/os/apps/BlogApp.tsx
+++ b/src/components/os/apps/BlogApp.tsx
@@ -16,10 +16,14 @@ type BlogPayload = {
   fetchedAt: string;
 };
 
+// pubDate is UTC midnight from the post's bare YYYY-MM-DD frontmatter. This
+// renders in the viewer's browser, so without pinning the zone a reader in
+// Los Angeles sees a different day than one in Berlin for the same post.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 
 // Module-level cache to prevent duplicate fetches when the component

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -14,10 +14,14 @@ type Props = { post: CollectionEntry<'blog'> };
 const { post } = Astro.props;
 const { Content } = await render(post);
 
+// Blog frontmatter carries a bare YYYY-MM-DD, which z.coerce.date() parses as
+// UTC midnight. Without pinning the zone the date renders as the previous day
+// on any negative-offset build host, contradicting the <time datetime> beside it.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 ---
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,10 +6,14 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
   (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
 );
 
+// Blog frontmatter carries a bare YYYY-MM-DD, which z.coerce.date() parses as
+// UTC midnight. Without pinning the zone the date renders as the previous day
+// on any negative-offset build host, contradicting the <time datetime> beside it.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 ---
 

--- a/src/pages/frontier-commits/[slug].astro
+++ b/src/pages/frontier-commits/[slug].astro
@@ -14,10 +14,13 @@ export async function getStaticPaths() {
 type Props = { episode: Episode };
 const { episode } = Astro.props;
 
+// pubDate comes from the feed in UTC. Without pinning the zone the rendered
+// date is a property of the build host rather than of the episode.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 
 const totalMs = Math.round(episode.duration_s * 1000);

--- a/src/pages/frontier-commits/index.astro
+++ b/src/pages/frontier-commits/index.astro
@@ -7,10 +7,13 @@ import { showById } from '../../lib/shows';
 const episodes = await fetchFrontierEpisodes();
 const show = showById('frontier-commits')!;
 
+// pubDate comes from the feed in UTC. Without pinning the zone the rendered
+// date is a property of the build host rather than of the episode.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 ---
 

--- a/src/pages/podcast/[slug].astro
+++ b/src/pages/podcast/[slug].astro
@@ -18,10 +18,13 @@ export async function getStaticPaths() {
 type Props = { episode: Episode };
 const { episode } = Astro.props;
 
+// pubDate comes from the feed in UTC. Without pinning the zone the rendered
+// date is a property of the build host rather than of the episode.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 
 const totalMs = Math.round(episode.duration_s * 1000);

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -7,10 +7,13 @@ import { showById } from '../../lib/shows';
 const episodes = await fetchEpisodes();
 const show = showById('cortech-daily')!;
 
+// pubDate comes from the feed in UTC. Without pinning the zone the rendered
+// date is a property of the build host rather than of the episode.
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC',
 });
 ---
 


### PR DESCRIPTION
Closes #222.

Every `Intl.DateTimeFormat` in `src/` now carries `timeZone: 'UTC'`, so a post's rendered date is a property of its content rather than of the machine that built the page.

## The bug

Blog frontmatter carries a bare `pubDate: YYYY-MM-DD`, which `z.coerce.date()` parses as UTC midnight — the single value guaranteed to land on the previous day in every western zone. The formatters had no `timeZone`, so **every** blog post rendered a day early on a negative-offset builder, with the visible text contradicting the `<time datetime>` attribute in the same element. Production is correct today only because Cloudflare Pages happens to build in UTC.

`BlogApp.tsx` and `Timeline.tsx` render client-side, where the unpinned zone is the **viewer's** — a reader in Los Angeles saw a different day than one in Berlin for the same post.

## Scope note

The issue lists seven sites; this changes eight. `src/components/mythos/Timeline.tsx:44` formats bare `YYYY-MM-DD` history rows in the viewer's zone — same defect class, and acceptance criterion 4 ("no `Intl.DateTimeFormat` without an explicit `timeZone` remains in `src/`") covers it.

Display-only. Stored `pubDate` values, `datetime` attributes, sort order (on timestamps, already zone-independent) and the RSS RFC-822 output are untouched; each formatter keeps its existing `short`/`long` month style. No new dependencies.

## Evidence

Podcast and frontier-commits render an empty state locally (`EPISODES_MANIFEST_URL` unset), so those paths were exercised with synthetic manifests fed through `EPISODES_MANIFEST_URL` / `FRONTIER_MANIFEST_URL` carrying boundary-hugging stamps — `01:00Z` (previous day in EDT) and `23:30Z` (next day in Tokyo). 16 `<time>` elements across `dist/blog`, `dist/podcast`, `dist/frontier-commits`.

**Criterion 2** — visible text vs. the calendar date of its own `datetime` attribute:

| build | parsed | mismatches |
|---|---|---|
| pre-fix, `TZ=America/New_York` | 16 | **12** |
| post-fix, `TZ=America/New_York` | 16 | 0 |

Pre-fix sample:

```
MISMATCH: 2026-04-16T00:00:00.000Z -> "Apr 15, 2026"   | UTC calendar date is Apr 16, 2026
MISMATCH: 2026-04-18T00:00:00.000Z -> "April 17, 2026" | UTC calendar date is Apr 18, 2026
MISMATCH: 2026-05-23T01:00:00.000Z -> "May 22, 2026"   | UTC calendar date is May 23, 2026
```

**Criterion 1** — three full builds, rendered date strings extracted and sorted:

```
America/New_York:  16 <time> elements
UTC:               16 <time> elements
Asia/Tokyo:        16 <time> elements

diff EDT vs UTC    -> IDENTICAL
diff UTC vs Tokyo  -> IDENTICAL
```

**Criterion 3** — `BlogApp.tsx` is client-side, so no build check can prove it. New `BlogApp.test.tsx` renders the app under `America/Los_Angeles`, `UTC` and `Asia/Tokyo` (the formatter is module-level, so `vi.resetModules()` rebuilds it per zone) and asserts `Apr 16, 2026` in all three. Confirmed failing for the right reason with the pin removed:

```
AssertionError: expected 'Apr 15, 2026' to be 'Apr 16, 2026'
Tests  1 failed | 2 passed (3)
```

**Criterion 4** — `grep -rn "Intl.DateTimeFormat" src` returns 11 matches; all 11 carry `timeZone: 'UTC'`.

**Criterion 5** — full gate suite on the rebased branch:

```
format:check  All matched files use Prettier code style!
lint          clean
typecheck     131 files: 0 errors, 0 warnings, 1 hint (pre-existing)
test          34 files, 297 tests passing
build         26 pages built
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)