### PR TITLE
chore(mythos): log 2026-08-26 tracker run

### DIFF
--- a/src/content/mythos/_data/history.jsonl
+++ b/src/content/mythos/_data/history.jsonl
@@ -66,3 +66,4 @@
 {"date":"2026-07-25","disclosed":2290,"acknowledged":1815,"fixed":420,"advisories":459,"severity":{"critical":157,"high":962,"medium":651,"low":513,"unknown":7}}
 {"date":"2026-08-09","disclosed":2294,"acknowledged":1815,"fixed":420,"advisories":459,"severity":{"critical":157,"high":966,"medium":651,"low":513,"unknown":7}}
 {"date":"2026-08-10","disclosed":2300,"acknowledged":1815,"fixed":421,"advisories":462,"severity":{"critical":157,"high":972,"medium":651,"low":513,"unknown":7}}
+{"date":"2026-08-26","disclosed":2300,"acknowledged":1815,"fixed":421,"advisories":462,"median_days_to_ack":0,"median_days_to_patch":13.7,"severity":{"critical":157,"high":972,"medium":651,"low":513,"unknown":7}}


### PR DESCRIPTION
## Summary
- Daily Mythos tracker run for 2026-08-26 fetched `https://red.anthropic.com/2026/cvd/data/payload.json`
- Payload `as_of` timestamp was unchanged since the last stored snapshot, so no triggers fired and no post was generated
- The only change is the append-only run-history ledger row for today (`src/content/mythos/_data/history.jsonl`) — `src/content/mythos/_data/snapshot.json` is untouched

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (327 passed)
- [ ] `npm run build` — fails in this sandbox on a pre-existing, unrelated issue: `/api/projects.json` needs a `GITHUB_TOKEN` not available in this environment. Confirmed by stashing this change and rebuilding on `main` alone — identical failure. Not caused by this diff.

Source: https://red.anthropic.com/2026/cvd/


---
_Generated by [Claude Code](https://claude.ai/code/session_01CfZ3QgYLBLkG2svFA6Q13U)_